### PR TITLE
修正安徽中医药高等专科学校(AHZYYGZ)入口地址

### DIFF
--- a/resources/AHZYYGZ/adapters.yaml
+++ b/resources/AHZYYGZ/adapters.yaml
@@ -3,6 +3,6 @@ adapters:
     adapter_name: "安徽中医药高等专科学校" 
     category: "BACHELOR_AND_ASSOCIATE"
     asset_js_path: "AHZYYGZ.js" 
-    import_url: "https://jwxt.ahzyygz.edu.cn/ahzyygzjw/frame/homes.action?v=57985306490269832436839"
+    import_url: "https://authserver.ahzyygz.edu.cn/authserver/login?service=http://jwxt.ahzyygz.edu.cn/ahzyygzjw/caslogin"
     maintainer: "glxgo"
     description: "安徽中医药高等专科学校青果教务适配器，非本校开发者适配，如果有误建议提交issues"


### PR DESCRIPTION
## 修正内容

- **学校**: 安徽中医药高等专科学校
- **ID**: AHZYYGZ
- **旧地址**: https://jwxt.ahzyygz.edu.cn/ahzyygzjw/frame/homes.action?v=...
- **新地址**: https://authserver.ahzyygz.edu.cn/authserver/login?service=http://jwxt.ahzyygz.edu.cn/ahzyygzjw/caslogin

改为 authserver CAS 统一认证登录入口。