### PR TITLE
fix: IMNC移除HTML的wbr标签

### DIFF
--- a/resources/IMNC/imnc_01.js
+++ b/resources/IMNC/imnc_01.js
@@ -3,6 +3,11 @@
  * 放置于测试目录用于真机测试
  */
 
+// 清理 <wbr> 标签
+function cleanWbr(str) {
+    return str ? str.replace(/<wbr\s*\/?>/gi, '') : str;
+}
+
 // 周次解析函数
 function parseWeeks(weekStr) {
     let weeks = [];
@@ -71,6 +76,11 @@ function fetchAndParseCourses() {
                     let nameMatch2 = namePart.match(/<<(.*?)>>/);
                     if (nameMatch2) name = nameMatch2[1];
                 }
+                
+                // 清理 <wbr> 标签
+                name = cleanWbr(name);
+                position = cleanWbr(position);
+                teacher = cleanWbr(teacher);
                 
                 let weeks = parseWeeks(weekStr);
                 


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)  

### 本仓库已经开启main分支保护请不要提交pr到main  

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)  


## PR 描述 (Description)

本次 PR 解决了什么问题？/ 引入了哪些新功能？
教务系统 HTML 页面中，较长的课程名称、地点和教师名称会被插入 <wbr> 标签来控制换行。
脚本使用 innerHTML 获取内容并用正则表达式提取，但没有清理这些 <wbr> 标签，导致课表也出现了这些标签。
本次 PR 新增的代码移除了这些标签。