### PR TITLE
feat: 新增广东海洋大学阳江校区教务适配

### DIFF
--- a/resources/GDOU/adapters.yaml
+++ b/resources/GDOU/adapters.yaml
@@ -7,3 +7,12 @@ adapters:
     import_url: "https://jw.gdou.edu.cn/"
     maintainer: "Mccurtain"
     description: "广东海洋大学教务适配，如有误请提交 issues"
+
+  - adapter_id: "GDOUYJ_01"
+    adapter_name: "广东海洋大学阳江校区教务"
+    category: "BACHELOR_AND_ASSOCIATE"
+    asset_js_path: "gdouyj.js"
+    import_url: "https://jw.gdou.edu.cn/"
+    maintainer: "Yihe-ng"
+    description: "广东海洋大学阳江校区教务适配，使用阳江校区教学楼错峰作息时间，如有误请提交issues"
+

--- a/resources/GDOU/gdouyj.js
+++ b/resources/GDOU/gdouyj.js
@@ -1,7 +1,8 @@
 /**
- * 广东海洋大学教务适配
+ * 广东海洋大学阳江校区教务适配
  * @date 2026-7-30
- * @author Mccurtain
+ * @author Mccurtain (原始 GDOU 适配)
+ * @adapted-by Yihe-ng (阳江校区作息与适配)
  * @version 1.1
  */
 
@@ -76,6 +77,25 @@ function parseSectionRange(sectionStr) {
 }
 
 /**
+ * 阳江校区其他场地（非慎思楼）的作息。
+ * 只有第 3、4 节在校区作息表中是不同的连续时间块，使用自定义时间表示。
+ */
+const OTHER_VENUE_SECTION_3_4_TIME = { startTime: "10:10", endTime: "11:40" };
+
+function getOtherVenueCustomTime(position, startSection, endSection) {
+    const positionText = position == null ? '' : String(position);
+    if (!positionText || positionText.includes("慎思楼")) {
+        return null;
+    }
+
+    if (startSection !== 3 || endSection !== 4) {
+        return null;
+    }
+
+    return OTHER_VENUE_SECTION_3_4_TIME;
+}
+
+/**
  * 解析正方 v9 课表查询接口返回的 JSON 数据。
  */
 function parseJsonData(jsonData) {
@@ -131,6 +151,17 @@ function parseJsonData(jsonData) {
             weeks: weeksArray
         };
 
+        const customTime = getOtherVenueCustomTime(
+            course.position,
+            course.startSection,
+            course.endSection
+        );
+        if (customTime) {
+            course.isCustomTime = true;
+            course.customStartTime = customTime.startTime;
+            course.customEndTime = customTime.endTime;
+        }
+
         finalCourseList.push(course);
     }
 
@@ -171,8 +202,8 @@ function getDefaultAcademicYear(date = new Date()) {
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
     return await window.AndroidBridgePromise.showAlert(
-        "广东海洋大学教务系统课表导入",
-        "导入前请确保您已在浏览器中成功登录广东海洋大学教务系统（jw.gdou.edu.cn）。\n本脚本将通过接口直接获取课表，无需停留在特定页面。",
+        "广东海洋大学阳江校区教务系统课表导入",
+        "导入前请确保您已在浏览器中成功登录广东海洋大学教务系统（jw.gdou.edu.cn）。\n本脚本将通过接口直接获取阳江校区课表，无需停留在特定页面。",
         "好的，开始导入"
     );
 }
@@ -277,16 +308,16 @@ async function saveCourses(parsedCourses) {
     }
 }
 
-// 广东海洋大学通用上课时间
+// 阳江校区慎思楼上课时间（根据用户提供的校区作息表）
 const TimeSlots = [
     { number: 1, startTime: "08:10", endTime: "08:55" },
-    { number: 2, startTime: "09:00", endTime: "09:45" },
-    { number: 3, startTime: "10:15", endTime: "11:00" },
-    { number: 4, startTime: "11:05", endTime: "11:50" },
+    { number: 2, startTime: "09:05", endTime: "09:50" },
+    { number: 3, startTime: "10:20", endTime: "11:05" },
+    { number: 4, startTime: "11:15", endTime: "12:00" },
     { number: 5, startTime: "14:30", endTime: "15:15" },
     { number: 6, startTime: "15:20", endTime: "16:05" },
-    { number: 7, startTime: "16:30", endTime: "17:15" },
-    { number: 8, startTime: "17:20", endTime: "18:05" },
+    { number: 7, startTime: "16:20", endTime: "17:05" },
+    { number: 8, startTime: "17:10", endTime: "17:55" },
     { number: 9, startTime: "19:30", endTime: "20:15" },
     { number: 10, startTime: "20:25", endTime: "21:10" }
 ];


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)

## PR 描述 (Description)

新增广东海洋大学阳江校区教务适配，并保留原广东海洋大学通用教务适配。

### 变更内容

- 在 `resources/GDOU/adapters.yaml` 中新增 `GDOUYJ_01`，显示名称为“广东海洋大学阳江校区教务”。
- 新增 `resources/GDOU/gdouyj.js`，复用广东海洋大学正方教务 API 和课程解析流程。
- 阳江校区使用独立作息：慎思楼使用统一作息，其他场地第 3～4 节使用 `10:10-11:40`。
- 保留原始 GDOU 适配作者署名，并在阳江脚本中标注阳江校区适配维护者。
- 改进通用课程解析：支持中文逗号、单节课、异常节次跳过，以及教师/教室为空的课程记录。
- 改进学年默认值和配置保存失败处理。

### 测试情况

- 已通过拾光课程表开发者功能的自定义仓库 Beta 真机测试。
- 已验证广东海洋大学原适配和广东海洋大学阳江校区适配均可显示并导入课程。
- 已使用阳江校区真实课表核对慎思楼、博学楼、厚为楼课程时间。
- 已通过 Node.js 语法检查、模拟课程解析和 YAML 适配器引用校验。
- 未提交 `school_index.pb`、`index-pb-release`、账号、密码、Cookie 或个人课表数据。
- `semesterStartDate` 按测试需求保持手动/未自动猜测；学期总周数按当前适配要求保持 20 周。
