### PR TITLE
refactor: 升级桥接接口至v2

### DIFF
--- a/resources/AHSZU/ahszu_01.js
+++ b/resources/AHSZU/ahszu_01.js
@@ -17,7 +17,7 @@ async function checkLoginEnvironment() {
     const currentUrl = window.location.href;
     const loginUrl = "http://211.86.128.194/suzxyjw/cas/login.action";
     if (currentUrl.includes(loginUrl)) {
-        AndroidBridge.showToast("请先登录教务系统再进行导入");
+        window.shiguangBridge.showToast("请先登录教务系统再进行导入");
         return false;
     }
     return true;
@@ -156,7 +156,7 @@ function parseAndMergeXmcuData(htmlText) {
  */
 async function getYearAndSemester() {
     try {
-        AndroidBridge.showToast("正在获取学期列表...");
+        window.shiguangBridge.showToast("正在获取学期列表...");
         const response = await fetch("http://211.86.128.194/suzxyjw/frame/droplist/getDropLists.action", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
@@ -165,12 +165,12 @@ async function getYearAndSemester() {
         });
         const list = await response.json();
         const names = list.map(item => item.name);
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection("选择导入学期", JSON.stringify(names), 0);
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection("选择导入学期", JSON.stringify(names), 0);
         if (selectedIndex === null) return null;
         const [xn, xq] = list[selectedIndex].code.split('-');
         return { xn, xq };
     } catch (error) {
-        AndroidBridge.showToast("获取列表失败");
+        window.shiguangBridge.showToast("获取列表失败");
         return null;
     }
 }
@@ -182,13 +182,13 @@ async function fetchCourses(xn, xq) {
     try {
         const paramsBase64 = encodeParams(xn, xq);
         const url = `http://211.86.128.194/suzxyjw/student/wsxk.xskcb10319.jsp?params=${paramsBase64}`;
-        AndroidBridge.showToast("正在提取数据...");
+        window.shiguangBridge.showToast("正在提取数据...");
         const response = await fetch(url, { method: "GET", credentials: "include" });
         const arrayBuffer = await response.arrayBuffer();
         const htmlText = new TextDecoder('gbk').decode(arrayBuffer);
         return parseAndMergeXmcuData(htmlText);
     } catch (error) {
-        AndroidBridge.showToast("抓取课表失败");
+        window.shiguangBridge.showToast("抓取课表失败");
         return null;
     }
 }
@@ -210,7 +210,7 @@ async function importPresetTimeSlots() {
         { "number": 10, "startTime": "19:55", "endTime": "20:40" },
         { "number": 11, "startTime": "20:50", "endTime": "21:35" }
     ];
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(slots)).catch(() => {});
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(slots)).catch(() => {});
 }
 
 /**
@@ -222,7 +222,7 @@ async function runImportFlow() {
     if (!isReady) return;
 
     // 弹窗确认
-    const confirmed = await window.AndroidBridgePromise.showAlert("教务导入", "建议在‘课表查询’页面进行导入以确保数据最全。", "确定");
+    const confirmed = await window.shiguangBridgePromise.showAlert("教务导入", "建议在‘课表查询’页面进行导入以确保数据最全。", "确定");
     if (!confirmed) return;
 
     // 选择学期
@@ -232,17 +232,17 @@ async function runImportFlow() {
     // 获取并解析数据
     const courses = await fetchCourses(params.xn, params.xq);
     if (!courses || courses.length === 0) {
-        AndroidBridge.showToast("未找到有效课程");
+        window.shiguangBridge.showToast("未找到有效课程");
         return;
     }
 
     // 存储
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
     await importPresetTimeSlots();
 
     // 完成
-    AndroidBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动

--- a/resources/AHZYYGZ/AHZYYGZ.js
+++ b/resources/AHZYYGZ/AHZYYGZ.js
@@ -157,7 +157,7 @@ async function resolveTermSelection() {
     throw new Error('未读取到学期列表，请先进入“学生个人课表”页面');
   }
 
-  const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学期',
     JSON.stringify(options.map(item => item.text)),
     defaultIndex
@@ -386,7 +386,7 @@ async function loadTimetableDoc(term) {
 
 async function runImportFlow() {
   try {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
       '安徽中医药高等专科学校教务导入',
       '请确认你已登录教务系统，并且最好已经打开“学生个人课表”页面。',
       '确定，开始导入'
@@ -394,7 +394,7 @@ async function runImportFlow() {
     if (!confirmed) return;
 
     const term = await resolveTermSelection();
-    AndroidBridge.showToast('正在提取青果课表数据...');
+    window.shiguangBridge.showToast('正在提取青果课表数据...');
     const doc = await loadTimetableDoc(term);
     const courses = parseAndMergeQingguoTable(doc);
     if (!courses.length) {
@@ -404,19 +404,19 @@ async function runImportFlow() {
     const allWeeks = courses.flatMap(course => course.weeks);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks,
       semesterStartDate: null,
       firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (error) {
     console.error(error);
-    AndroidBridge.showToast(`导入失败: ${error.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${error.message}`);
   }
 }
 

--- a/resources/BUPT/bupt_01.js
+++ b/resources/BUPT/bupt_01.js
@@ -4,16 +4,16 @@
 
 (function () {
     function toast(message) {
-        if (window.AndroidBridge && AndroidBridge.showToast) {
-            AndroidBridge.showToast(message);
+        if (window.shiguangBridge && window.shiguangBridge.showToast) {
+            window.shiguangBridge.showToast(message);
         } else {
             console.log(message);
         }
     }
 
     async function alertUser(title, message) {
-        if (window.AndroidBridgePromise && window.AndroidBridgePromise.showAlert) {
-            return await window.AndroidBridgePromise.showAlert(title, message, "确定");
+        if (window.shiguangBridgePromise && window.shiguangBridgePromise.showAlert) {
+            return await window.shiguangBridgePromise.showAlert(title, message, "确定");
         }
         alert(title + "\n" + message);
         return true;
@@ -262,15 +262,15 @@
             defaultBreakDuration: 5
         };
 
-        if (window.AndroidBridgePromise && window.AndroidBridgePromise.saveCourseConfig) {
-            await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        if (window.shiguangBridgePromise && window.shiguangBridgePromise.saveCourseConfig) {
+            await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
         }
-        if (timeSlots.length > 0 && window.AndroidBridgePromise && window.AndroidBridgePromise.savePresetTimeSlots) {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        if (timeSlots.length > 0 && window.shiguangBridgePromise && window.shiguangBridgePromise.savePresetTimeSlots) {
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         }
 
-        if (window.AndroidBridgePromise && window.AndroidBridgePromise.saveImportedCourses) {
-            return await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        if (window.shiguangBridgePromise && window.shiguangBridgePromise.saveImportedCourses) {
+            return await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         }
 
         console.log("BUPT parsed courses:", JSON.stringify(courses, null, 2));
@@ -313,8 +313,8 @@
             }
 
             toast(`导入成功：${courses.length} 个课程时段${timeSlots.length ? "，已同步作息时间" : ""}`);
-            if (window.AndroidBridge && AndroidBridge.notifyTaskCompletion) {
-                AndroidBridge.notifyTaskCompletion();
+            if (window.shiguangBridge && window.shiguangBridge.notifyTaskCompletion) {
+                window.shiguangBridge.notifyTaskCompletion();
             }
         } catch (error) {
             console.error("BUPT import failed:", error);

--- a/resources/CAPU/capadap.js
+++ b/resources/CAPU/capadap.js
@@ -6,16 +6,16 @@
  * 显示导入提示
  */
 async function promptUserToStart() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "导入确认",
         "请确保您已经登录咯~",
         "开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入");
+        window.shiguangBridge.showToast("用户取消了导入");
         return false;
     }
-    AndroidBridge.showToast("开始流程咯~");
+    window.shiguangBridge.showToast("开始流程咯~");
     return true;
 }
 
@@ -102,7 +102,7 @@ async function extractCourseTime() {
         };
     } catch (error) {
         console.error('解析基础信息时出错:', error);
-        AndroidBridge.showToast(`解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`解析失败: ${error.message}`);
         return null;
     }
 }
@@ -351,7 +351,7 @@ async function fetchAllRawData() {
     const rawArrangedList = await getCourseData(baseInfo.totalWeeks);
 
     if (!rawArrangedList || rawArrangedList.length === 0) {
-        AndroidBridge.showToast("未检测到当前学期的课程数据");
+        window.shiguangBridge.showToast("未检测到当前学期的课程数据");
         return null;
     }
     return { baseInfo, rawArrangedList };
@@ -364,14 +364,14 @@ async function saveConfig(baseInfo) {
         semesterTotalWeeks: baseInfo.totalWeeks || 20,
     };
     try {
-        const configSuccess = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        const configSuccess = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
         if (!configSuccess) {
-            AndroidBridge.showToast("学期保存失败");
+            window.shiguangBridge.showToast("学期保存失败");
             return false;
         }
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
@@ -387,7 +387,7 @@ async function runImportFlow() {
 
         const { courses: finalCourses, timeSlots } = parseAllCourses(dataBundle.rawArrangedList, dataBundle.baseInfo.cleanSections);
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("解析失败：未能提取到有效课程");
+            window.shiguangBridge.showToast("解析失败：未能提取到有效课程");
             return;
         }
 
@@ -399,26 +399,26 @@ async function runImportFlow() {
         try {
             const slotJson = JSON.stringify(timeSlots);
             console.log("写入时间段数据:", slotJson);
-            await window.AndroidBridgePromise.savePresetTimeSlots(slotJson);
+            await window.shiguangBridgePromise.savePresetTimeSlots(slotJson);
         } catch (e) {
             console.error("时间段写入失败:", e);
-            AndroidBridge.showToast("时间段保存失败");
+            window.shiguangBridge.showToast("时间段保存失败");
             return;
         }
 
         // 保存课程数据
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         if (!saveResult) {
-            AndroidBridge.showToast("课程数据保存失败");
+            window.shiguangBridge.showToast("课程数据保存失败");
             return;
         }
 
-        AndroidBridge.showToast("Hi ~ 课表导入成功！");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("Hi ~ 课表导入成功！");
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error("主流程异常:", error);
-        AndroidBridge.showToast("意外错误: " + error.message);
+        window.shiguangBridge.showToast("意外错误: " + error.message);
     }
 }
 

--- a/resources/CAUC/cauc.js
+++ b/resources/CAUC/cauc.js
@@ -126,7 +126,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -136,7 +136,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -147,7 +147,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         -1
@@ -202,19 +202,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         console.error(`Request failed: ${targetUrl}`, e);
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -240,17 +240,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -260,14 +260,14 @@ async function runImportFlow() {
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -276,7 +276,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -296,10 +296,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -307,9 +307,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/CCIT/ccit.js
+++ b/resources/CCIT/ccit.js
@@ -196,7 +196,7 @@ function parseTimetableToModel(doc) {
 
 async function saveAppConfig() {
     const config = { "semesterTotalWeeks": 20, "firstDayOfWeek": 1 };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 async function saveAppTimeSlots() {
@@ -214,24 +214,24 @@ async function saveAppTimeSlots() {
         { "number": 11, "startTime": "19:40", "endTime": "20:25" },
         { "number": 12, "startTime": "20:30", "endTime": "21:15" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
+        const confirmed = await window.shiguangBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
         if (!confirmed) return;
 
         const currentYear = new Date().getFullYear();
-        const year = await window.AndroidBridgePromise.showPrompt("选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput");
+        const year = await window.shiguangBridgePromise.showPrompt("选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput");
         if (!year) return;
 
-        const semesterIndex = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), 0);
+        const semesterIndex = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), 0);
         if (semesterIndex === null) return;
 
         const semesterId = `${year}-${parseInt(year) + 1}-${semesterIndex + 1}`;
 
-        AndroidBridge.showToast("正在请求数据...");
+        window.shiguangBridge.showToast("正在请求数据...");
         const response = await fetch("https://http-10-198-47-148-8080.webvpn.ccit.edu.cn/jsxsd/xskb/xskb_list.do", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -243,18 +243,18 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程，请检查学期选择或登录状态。");
+            window.shiguangBridge.showToast("未发现课程，请检查学期选择或登录状态。");
             return;
         }
 
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses)); //[cite: 1]
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses)); //[cite: 1]
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/CFEC/CFEC.js
+++ b/resources/CFEC/CFEC.js
@@ -80,14 +80,14 @@ async function fetchIndexDoc() {
 async function selectTermByUserFromDoc(doc) {
   const { yearData, semesterData } = parseTermOptionsFromDoc(doc);
 
-  const yearIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const yearIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学年',
     JSON.stringify(yearData.options.map(item => item.text)),
     yearData.defaultIndex
   );
   if (yearIndex === null || yearIndex === -1) throw new Error('已取消学年选择');
 
-  const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学期',
     JSON.stringify(semesterData.options.map(item => item.text)),
     semesterData.defaultIndex
@@ -175,7 +175,7 @@ async function fetchCourses(xnm, xqm) {
 async function run() {
   try {
     const { xnm, xqm } = await resolveTerm();
-    AndroidBridge.showToast('正在解析课表数据...');
+    window.shiguangBridge.showToast('正在解析课表数据...');
 
     const rawData = await fetchCourses(xnm, xqm);
     const { courses } = parseCourses(rawData);
@@ -184,19 +184,19 @@ async function run() {
     const allWeeks = courses.flatMap(course => course.weeks);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks,
       semesterStartDate: null,
       firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：${courses.length} 门`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：${courses.length} 门`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (error) {
     console.error(error);
-    AndroidBridge.showToast(`导入失败: ${error.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${error.message}`);
   }
 }
 

--- a/resources/CJLU/cjlu.js
+++ b/resources/CJLU/cjlu.js
@@ -148,7 +148,7 @@ function buildCourseConfig(courses) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录中国计量大学教务系统。",
         "好的，开始导入"
@@ -168,7 +168,7 @@ function validateYearInput(input) {
 async function getAcademicYear() {
     const defaultYear = new Date().getFullYear();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2026-2027 应输入2026）:",
         String(defaultYear),
@@ -179,7 +179,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -197,7 +197,7 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
     const semesterCode = getSemesterCode(semesterIndex);
     const requestBody = `xnm=${encodeURIComponent(academicYear)}&xqm=${encodeURIComponent(semesterCode)}&kzlx=ck&xsdm=&kclbdm=&kclxdm=`;
     let lastError = "";
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
 
     for (const url of COURSE_API_PATHS) {
         try {
@@ -229,8 +229,8 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         }
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查登录状态或学年学期。");
-    await window.AndroidBridgePromise.showAlert(
+    window.shiguangBridge.showToast("未能获取课表数据，请检查登录状态或学年学期。");
+    await window.shiguangBridgePromise.showAlert(
         "导入失败",
         `未能获取课表数据。已使用同源相对路径尝试 /kbcx 和 /jwglxt/kbcx 接口。\n最后错误：${lastError || "未知错误"}`,
         "确定"
@@ -239,14 +239,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -271,12 +271,12 @@ const TimeSlots = [
 
 async function importPresetTimeSlots(timeSlots) {
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     }
@@ -285,20 +285,20 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     if (!isOnCjluJwxt()) {
         const msg = "当前页面不在中国计量大学教务系统域名内，请先打开并登录 https://jwxt.cjlu.edu.cn/jwglxt/ 后再导入。";
-        AndroidBridge.showToast("请先进入中国计量大学教务系统。");
-        await window.AndroidBridgePromise.showAlert("导入失败", msg, "确定");
+        window.shiguangBridge.showToast("请先进入中国计量大学教务系统。");
+        await window.shiguangBridgePromise.showAlert("导入失败", msg, "确定");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -306,7 +306,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -326,18 +326,18 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/CMC/cmc_01.js
+++ b/resources/CMC/cmc_01.js
@@ -173,7 +173,7 @@ function extractSemesterOptions(doc) {
 
 // 导入前提示用户先登录教务系统
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "成都医学院教务导入",
         "请先确保已登录教务系统，再继续导入。",
         "我已登录"
@@ -182,7 +182,7 @@ async function promptUserToStart() {
 
 // 从页面已有学期中选择目标学期
 async function selectSemester(semesterOptions) {
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesterOptions.semesters),
         semesterOptions.defaultIndex
@@ -196,7 +196,7 @@ async function selectSemester(semesterOptions) {
 
 // 询问是否同时导入考试
 async function askImportExams() {
-    const bridge = window.AndroidBridgePromise;
+    const bridge = window.shiguangBridgePromise;
     if (!bridge || typeof bridge.showAlert !== "function") return true;
     return await bridge.showAlert(
         "导入考试安排",
@@ -264,33 +264,33 @@ async function fetchExamData(xnxqdm) {
 }
 
 async function saveCourses(courses) {
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 }
 
 async function saveTimeSlots(timeSlots) {
     if (timeSlots.length === 0) return;
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 // 编排导入流程：提示 → 选学期 → 请求课表与考试 → 合并保存课程与作息时间
 async function runImportFlow() {
     try {
         const confirmed = await promptUserToStart();
-        if (!confirmed) { AndroidBridge.showToast("导入已取消"); return; }
+        if (!confirmed) { window.shiguangBridge.showToast("导入已取消"); return; }
 
         const pageHtml = await fetchSchedulePage();
         const semesterOptions = extractSemesterOptions(new DOMParser().parseFromString(pageHtml, "text/html"));
         if (!semesterOptions) throw new Error("未找到学期列表，请先登录教务系统");
 
         const semester = await selectSemester(semesterOptions);
-        if (!semester) { AndroidBridge.showToast("导入已取消"); return; }
+        if (!semester) { window.shiguangBridge.showToast("导入已取消"); return; }
 
         const { slots, map: slotMap } = parseBusinessHoursFromHtml(pageHtml);
-        AndroidBridge.showToast(`正在获取 ${semester.label} 的课表...`);
+        window.shiguangBridge.showToast(`正在获取 ${semester.label} 的课表...`);
         const courses = parseCourseList(await fetchCourseData(semester.value), slotMap);
 
         if (courses.length === 0) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "提示",
                 "该学期没有获取到课程数据，请检查登录状态和所选学期。",
                 "确定"
@@ -306,23 +306,23 @@ async function runImportFlow() {
                 if (c.startSection >= 6) c.startSection += 1;
                 if (c.endSection >= 6) c.endSection += 1;
             });
-            AndroidBridge.showToast("正在获取考试安排...");
+            window.shiguangBridge.showToast("正在获取考试安排...");
             exams.push(...parseExamList(await fetchExamData(semester.value), timeSlots));
-            if (exams.length === 0) AndroidBridge.showToast("该学期暂时没有考试安排");
+            if (exams.length === 0) window.shiguangBridge.showToast("该学期暂时没有考试安排");
         }
 
         await saveCourses([...courses, ...exams]);
         try {
             await saveTimeSlots(timeSlots);
         } catch (error) {
-            AndroidBridge.showToast(`课程已导入，作息时间导入失败：${error.message}`);
+            window.shiguangBridge.showToast(`课程已导入，作息时间导入失败：${error.message}`);
         }
 
         const examTip = exams.length > 0 ? `成功导入 ${exams.length} 门考试` : "导入完成";
-        AndroidBridge.showToast(examTip);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(examTip);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "导入失败",
             error.message || String(error),
             "确定"

--- a/resources/CQCIVC/cqcivc.js
+++ b/resources/CQCIVC/cqcivc.js
@@ -137,7 +137,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -147,7 +147,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -158,7 +158,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -179,7 +179,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -211,14 +211,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -236,21 +236,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -275,17 +275,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -293,21 +293,21 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -316,7 +316,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -336,10 +336,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -347,9 +347,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/CQCST/cqcst_01.js
+++ b/resources/CQCST/cqcst_01.js
@@ -1,7 +1,7 @@
 async function runImportFlow() {
     // 兼容电脑端测试
-    if (typeof window.AndroidBridgePromise === 'undefined') {
-        window.AndroidBridgePromise = {
+    if (typeof window.shiguangBridgePromise === 'undefined') {
+        window.shiguangBridgePromise = {
             showAlert: async () => true,
             saveImportedCourses: async (json) => {
                 console.log("===============================");
@@ -12,21 +12,21 @@ async function runImportFlow() {
                 return true;
             }
         };
-        window.AndroidBridge = {
+        window.shiguangBridge = {
             showToast: (msg) => console.log("[系统提示] " + msg),
             notifyTaskCompletion: () => console.log("[流程结束] 任务已完成并通知APP")
         };
     }
 
-    AndroidBridge.showToast("开始提取课表数据...");
+    window.shiguangBridge.showToast("开始提取课表数据...");
 
     const table = document.getElementById('kbtable') || document.querySelector('.table_border') || document.querySelector('table');
     if (!table || !table.innerText.includes('星期')) {
-        AndroidBridge.showToast("没找到课表！请确保您当前在“学期理论课表”页面。");
+        window.shiguangBridge.showToast("没找到课表！请确保您当前在“学期理论课表”页面。");
         return;
     }
 
-    const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
         "强智教务解析",
         "已检测到课表页面，是否提取数据并导入？",
         "确认导入"
@@ -115,22 +115,22 @@ async function runImportFlow() {
         }
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("没有抓取到数据，可能当前表格为空。");
+            window.shiguangBridge.showToast("没有抓取到数据，可能当前表格为空。");
             return;
         }
 
-        AndroidBridge.showToast(`提取成功，共发现 ${courses.length} 门课程，正在保存...`);
+        window.shiguangBridge.showToast(`提取成功，共发现 ${courses.length} 门课程，正在保存...`);
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         
         if (saveResult) {
-            AndroidBridge.showToast("导入大功告成！");
-            AndroidBridge.notifyTaskCompletion(); 
+            window.shiguangBridge.showToast("导入大功告成！");
+            window.shiguangBridge.notifyTaskCompletion(); 
         }
 
     } catch (error) {
         console.error("解析过程中发生错误:", error);
-        AndroidBridge.showToast("解析出错啦: " + error.message);
+        window.shiguangBridge.showToast("解析出错啦: " + error.message);
     }
 }
 

--- a/resources/CQJTU/cqjtu.js
+++ b/resources/CQJTU/cqjtu.js
@@ -136,7 +136,7 @@ function parseSchedule() {
   let table = findElementInFrames("#timetable");
 
   if (!table) {
-    AndroidBridge.showToast("请去往学期理论课表界面");
+    window.shiguangBridge.showToast("请去往学期理论课表界面");
     return [];
   }
 
@@ -148,7 +148,7 @@ function parseSchedule() {
     if (rows.length > 0) {
       return parseRowsDirectly(rows);
     }
-    AndroidBridge.showToast("课表结构异常");
+    window.shiguangBridge.showToast("课表结构异常");
     return [];
   }
 
@@ -357,33 +357,33 @@ function parseRowsDirectly(rows) {
 // ===== 保存函数 =====
 
 async function saveCourses(courses) {
-  await window.AndroidBridgePromise.saveImportedCourses(
+  await window.shiguangBridgePromise.saveImportedCourses(
     JSON.stringify(courses),
   );
 }
 
 async function saveTimeSlots(timeSlots) {
-  await window.AndroidBridgePromise.savePresetTimeSlots(
+  await window.shiguangBridgePromise.savePresetTimeSlots(
     JSON.stringify(timeSlots),
   );
 }
 
 async function saveConfig(config) {
-  await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+  await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 // ===== 主流程 =====
 
 (async () => {
   if (!checkLogin()) {
-    AndroidBridge.showToast("尚未登录，请先登录！");
+    window.shiguangBridge.showToast("尚未登录，请先登录！");
     return;
   }
 
   const { courses, timeSlots } = parseSchedule();
 
   if (courses.length === 0) {
-    AndroidBridge.showToast("未解析到任何课程");
+    window.shiguangBridge.showToast("未解析到任何课程");
     return;
   }
 
@@ -405,6 +405,6 @@ async function saveConfig(config) {
   await saveTimeSlots(timeSlots);
   await saveConfig(courseConfigData);
 
-  AndroidBridge.showToast(`导入成功！${courses.length}门课程`);
-  AndroidBridge.notifyTaskCompletion();
+  window.shiguangBridge.showToast(`导入成功！${courses.length}门课程`);
+  window.shiguangBridge.notifyTaskCompletion();
 })();

--- a/resources/CQRK/cqrk_01.js
+++ b/resources/CQRK/cqrk_01.js
@@ -142,7 +142,7 @@ function parseTimetableToModel(doc) {
 
 async function saveAppConfig() {
     const config = { "semesterTotalWeeks": 20, "firstDayOfWeek": 1 };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -183,26 +183,26 @@ async function saveAppTimeSlots(semesterIndex) {
     ];
 
     const selectedSlots = (semesterIndex === 0) ? timeSlots_1 : timeSlots_2;
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(selectedSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(selectedSlots));
 }
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
+        const confirmed = await window.shiguangBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
         if (!confirmed) return;
 
         // 1. 获取学年
         const currentYear = new Date().getFullYear();
-        const year = await window.AndroidBridgePromise.showPrompt("选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput");
+        const year = await window.shiguangBridgePromise.showPrompt("选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput");
         if (!year) return;
 
         // 2. 获取学期并记录索引
-        const semesterIndex = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), 0);
+        const semesterIndex = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), 0);
         if (semesterIndex === null) return;
 
         const semesterId = `${year}-${parseInt(year) + 1}-${semesterIndex + 1}`;
 
-        AndroidBridge.showToast("正在请求数据...");
+        window.shiguangBridge.showToast("正在请求数据...");
         const response = await fetch("http://jwxt.cqrk.edu.cn:18080/jsxsd/xskb/xskb_list.do", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -214,18 +214,18 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程，请检查学期选择或登录状态。");
+            window.shiguangBridge.showToast("未发现课程，请检查学期选择或登录状态。");
             return;
         }
 
         await saveAppConfig();
         await saveAppTimeSlots(semesterIndex);
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/CQU/cqu.js
+++ b/resources/CQU/cqu.js
@@ -18,7 +18,7 @@ const baseFetch = async (url, accessToken, method, body, description) => {
         }
     );
     if (!response.ok) {
-        AndroidBridge.showToast(`获取${description}失败，请退出重试`);
+        window.shiguangBridge.showToast(`获取${description}失败，请退出重试`);
         throw new Error(`获取${description}失败: ${termResponse.status} ${termResponse.statusText}`);
     }
     return await response.json();
@@ -56,15 +56,15 @@ const parseSchedule = (startDate, maxWeek, timeSlots, schedule) => ({
 });
 
 const saveSchedule = (parsedSchedule) => Promise.allSettled([
-    window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(parsedSchedule?.courseConfig)),
-    window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedSchedule?.courses)),
-    window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(parsedSchedule?.timeSlots)),
+    window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(parsedSchedule?.courseConfig)),
+    window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedSchedule?.courses)),
+    window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(parsedSchedule?.timeSlots)),
 ]);
 
 
 (async () => {
     if (!checkLogin()) {
-        AndroidBridge.showToast("尚未登录重庆大学教务系统，请先登录！");
+        window.shiguangBridge.showToast("尚未登录重庆大学教务系统，请先登录！");
         throw new Error("未检测到登录状态");
     }
     
@@ -73,7 +73,7 @@ const saveSchedule = (parsedSchedule) => Promise.allSettled([
     const accessToken = getAccessToken();
 
     if (!accessToken) {
-        AndroidBridge.showToast("尚未登录");
+        window.shiguangBridge.showToast("尚未登录");
         throw new Error("未找到访问令牌，请确保已登录 my.cqu.edu.cn");
     }
 
@@ -81,5 +81,5 @@ const saveSchedule = (parsedSchedule) => Promise.allSettled([
 
     await saveSchedule(parseSchedule(...(await Promise.allSettled([getStartDate(termId, accessToken), getMaxWeek(termId, accessToken), getTimeSlots(accessToken), getSchedule(termId, accessToken, studentId)])).map(result => result.value)));
 
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 })();

--- a/resources/CQUET/cquet_01.js
+++ b/resources/CQUET/cquet_01.js
@@ -1,8 +1,8 @@
 (async function () {
   function toast(msg) {
     try {
-      if (window.AndroidBridge && typeof window.AndroidBridge.showToast === "function") {
-        window.AndroidBridge.showToast(String(msg));
+      if (window.shiguangBridge && typeof window.shiguangBridge.showToast === "function") {
+        window.shiguangBridge.showToast(String(msg));
       }
     } catch (_) {}
   }
@@ -16,8 +16,8 @@
       console.error(detail, error || "");
     } catch (_) {}
     try {
-      if (window.AndroidBridgePromise && typeof window.AndroidBridgePromise.showAlert === "function") {
-        await window.AndroidBridgePromise.showAlert("提示", detail, "确定");
+      if (window.shiguangBridgePromise && typeof window.shiguangBridgePromise.showAlert === "function") {
+        await window.shiguangBridgePromise.showAlert("提示", detail, "确定");
       }
     } catch (_) {}
     throw new Error(detail);
@@ -565,7 +565,7 @@
   }
 
   async function main() {
-    if (!window.AndroidBridgePromise || !window.AndroidBridge || typeof window.AndroidBridge.notifyTaskCompletion !== "function") {
+    if (!window.shiguangBridgePromise || !window.shiguangBridge || typeof window.shiguangBridge.notifyTaskCompletion !== "function") {
       throw new Error("桥接接口不可用");
     }
 
@@ -607,18 +607,18 @@
       throw new Error("课程字段转换后为空，无法保存");
     }
 
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
 
     if (parsed.timeSlots && parsed.timeSlots.length) {
-      await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(parsed.timeSlots));
+      await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(parsed.timeSlots));
     }
 
     if (parsed.config) {
-      await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(parsed.config));
+      await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(parsed.config));
     }
 
     toast("课表导入成功，共" + finalCourses.length + "门课程");
-    window.AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
   }
 
   try {

--- a/resources/CQUT/cqut_01.js
+++ b/resources/CQUT/cqut_01.js
@@ -19,14 +19,14 @@ const baseFetch = async (path, body, description) => {
     });
 
     if (!response.ok) {
-        AndroidBridge.showToast(`获取${description}失败，请确认已登录后重试`);
+        window.shiguangBridge.showToast(`获取${description}失败，请确认已登录后重试`);
         throw new Error(`获取${description}失败: ${response.status} ${response.statusText}`);
     }
 
     try {
         return await response.json();
     } catch (error) {
-        AndroidBridge.showToast(`解析${description}失败，请确认当前页面登录状态`);
+        window.shiguangBridge.showToast(`解析${description}失败，请确认当前页面登录状态`);
         throw new Error(`解析${description}失败: ${error.message}`);
     }
 };
@@ -134,15 +134,15 @@ const mergeCourses = (events) => {
 
 // 将解析后的结构写入 App（配置、课程列表、节次时间表）
 const saveSchedule = (parsedSchedule) => Promise.all([
-    window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(parsedSchedule.courseConfig)),
-    window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedSchedule.courses)),
-    window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(parsedSchedule.timeSlots)),
+    window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(parsedSchedule.courseConfig)),
+    window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedSchedule.courses)),
+    window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(parsedSchedule.timeSlots)),
 ]);
 
 // 主流程：校验页面 → 拉取用户/校区 → 拉取节次/当前学期信息 → 拉取全学期每周课程 → 合并保存
 (async () => {
     if (!checkLogin()) {
-        AndroidBridge.showToast('请先打开重庆理工大学课表页面并登录');
+        window.shiguangBridge.showToast('请先打开重庆理工大学课表页面并登录');
         throw new Error('当前不在重庆理工大学课表页面');
     }
 
@@ -151,7 +151,7 @@ const saveSchedule = (parsedSchedule) => Promise.all([
     const campusName = userInfo?.userCustomSetting?.campusName;
 
     if (!userID || !campusName) {
-        AndroidBridge.showToast('未获取到完整的用户信息，请确认已登录');
+        window.shiguangBridge.showToast('未获取到完整的用户信息，请确认已登录');
         throw new Error('用户信息不完整');
     }
 
@@ -166,7 +166,7 @@ const saveSchedule = (parsedSchedule) => Promise.all([
     const semesterStartDate = parseSemesterStartDate(yearTerm, currentWeekData?.weekDayList);
 
     if (!yearTerm || weekList.length === 0) {
-        AndroidBridge.showToast('未获取到当前学期信息');
+        window.shiguangBridge.showToast('未获取到当前学期信息');
         throw new Error('当前学期信息不完整');
     }
 
@@ -185,5 +185,5 @@ const saveSchedule = (parsedSchedule) => Promise.all([
         courses: mergeCourses(weekResults.flatMap((result) => result?.eventList ?? [])),
     });
 
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 })();

--- a/resources/CSUFT/csuft.js
+++ b/resources/CSUFT/csuft.js
@@ -118,17 +118,17 @@ function parseSchedule(doc) {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
+        const confirmed = await window.shiguangBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
         if (!confirmed) return;
 
-        const year = await window.AndroidBridgePromise.showPrompt("选择学年", "请输入要导入的起始学年（例如 2025-2026 应输入2025）:", "", "validateYearInput");
+        const year = await window.shiguangBridgePromise.showPrompt("选择学年", "请输入要导入的起始学年（例如 2025-2026 应输入2025）:", "", "validateYearInput");
         if (!year) return;
 
-        const semesterIdx = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), -1);
+        const semesterIdx = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), -1);
         if (semesterIdx === null) return;
 
         const semId = `${year}-${parseInt(year) + 1}-${semesterIdx + 1}`;
-        AndroidBridge.showToast("正在获取课表数据...");
+        window.shiguangBridge.showToast("正在获取课表数据...");
 
         const url = "https://http-jwgl-csuft-edu-cn-80.webvpn.csuft.edu.cn/jsxsd/xskb/xskb_list.do";
         const resp = await fetch(url, {
@@ -142,18 +142,18 @@ async function runImportFlow() {
         const courses = parseSchedule(new DOMParser().parseFromString(html, "text/html"));
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到课程，请检查学年学期选择或登录状态。");
+            window.shiguangBridge.showToast("未找到课程，请检查学年学期选择或登录状态。");
             return;
         }
 
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks: 20, firstDayOfWeek: 1 }));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks: 20, firstDayOfWeek: 1 }));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (err) {
-        AndroidBridge.showToast("错误: " + err.message);
+        window.shiguangBridge.showToast("错误: " + err.message);
     }
 }
 

--- a/resources/CTGU/ctgu.js
+++ b/resources/CTGU/ctgu.js
@@ -125,7 +125,7 @@ function applyCourseChanges(parsedCourses, rawChanges) {
     }
     
     if (successCount > 0) {
-        AndroidBridge.showToast(`已应用 ${successCount} 条调课/停课变更，获得实际课表。`);
+        window.shiguangBridge.showToast(`已应用 ${successCount} 条调课/停课变更，获得实际课表。`);
     }
     
     return parsedCourses.map(c => {
@@ -139,13 +139,13 @@ function applyCourseChanges(parsedCourses, rawChanges) {
 
 
 async function promptUserToStart() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "重要通知：三峡大学课表导入",
         "本流程将通过教务系统接口获取您的个人课表。\n重要提示:\n导入前请确保您已在浏览器中成功登录教务系统，且未关闭登录窗口，确认当前页面有显示课表不然获取不了数据",
         "好的，开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return null;
     }
     return true;
@@ -153,7 +153,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear();
-    const yearSelection = await window.AndroidBridgePromise.showPrompt(
+    const yearSelection = await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         String(currentYear), 
@@ -164,7 +164,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["1 (秋季学期/上学期)", "2 (春季学期/下学期)"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -191,14 +191,14 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         const response = await fetch(courseUrl, { "headers": headers, "body": courseBody, "method": "POST", "credentials": "include" });
         rawCourseData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求课表 API 失败，请检查网络和登录状态,以及是否跳转到课表页面");
+        window.shiguangBridge.showToast("请求课表 API 失败，请检查网络和登录状态,以及是否跳转到课表页面");
         console.error("Fetch Course Error:", e);
         return null;
     }
 
     const rawCourses = rawCourseData?.datas?.cxxszhxqkb?.rows || [];
     if (rawCourses.length === 0) {
-        AndroidBridge.showToast("该学期未查询到您的课程数据。");
+        window.shiguangBridge.showToast("该学期未查询到您的课程数据。");
         return null;
     }
     let parsedCourses = rawCourses.map(c => parseSingleCourse(c)).filter(c => c !== null);
@@ -210,7 +210,7 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         const response = await fetch(changeUrl, { "headers": headers, "body": changeBody, "method": "POST", "credentials": "include" });
         rawChangeData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求调课 API 失败，将使用未调整的课表数据。");
+        window.shiguangBridge.showToast("请求调课 API 失败，将使用未调整的课表数据。");
         console.error("Fetch Change Error:", e);
     }
     
@@ -235,15 +235,15 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
 
 async function saveCourses(parsedCourses) {
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("没有有效的课程数据可供保存。");
+        window.shiguangBridge.showToast("没有有效的课程数据可供保存。");
         return true;
     }
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存课程数据失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存课程数据失败: ${error.message}`);
         return false;
     }
 }
@@ -252,7 +252,7 @@ async function saveCourses(parsedCourses) {
  * 导入预设时间段数据
  */
 async function importPresetTimeSlots() {
-    AndroidBridge.showToast("正在导入预设节次时间...");
+    window.shiguangBridge.showToast("正在导入预设节次时间...");
     
     const presetTimeSlots = [
         { "number": 1, "startTime": "08:00", "endTime": "08:45" },
@@ -270,22 +270,22 @@ async function importPresetTimeSlots() {
     ];
 
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
         return true; 
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false; 
     }
 }
 
 async function saveConfig(configData) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
-        AndroidBridge.showToast("课表配置更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        window.shiguangBridge.showToast("课表配置更新成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
@@ -293,7 +293,7 @@ async function saveConfig(configData) {
 // 主流程入口
 
 async function runImportFlow() {
-    AndroidBridge.showToast("三峡大学课程导入流程启动...");
+    window.shiguangBridge.showToast("三峡大学课程导入流程启动...");
 
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
@@ -302,13 +302,13 @@ async function runImportFlow() {
     // 2. 获取用户输入参数 (学年和学期)。
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     
     const semesterCode = await selectSemester();
     if (semesterCode === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -328,8 +328,8 @@ async function runImportFlow() {
     if (!saveResult) return;
 
     // 7. 流程完全成功，发送结束信号。
-    AndroidBridge.showToast("所有任务已完成！课表导入成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！课表导入成功。");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/CUIT/cuit_bk_new.js
+++ b/resources/CUIT/cuit_bk_new.js
@@ -6,16 +6,16 @@
   "use strict";
 
   function showToast(msg) {
-    if (typeof AndroidBridge !== "undefined" && AndroidBridge.showToast) {
-      AndroidBridge.showToast(msg);
+    if (typeof window.shiguangBridge !== "undefined" && window.shiguangBridge.showToast) {
+      window.shiguangBridge.showToast(msg);
     } else {
       console.log("[Toast]", msg);
     }
   }
 
   async function showAlert(title, content, confirmText = "确定") {
-    if (typeof window.AndroidBridgePromise !== "undefined") {
-      return await window.AndroidBridgePromise.showAlert(
+    if (typeof window.shiguangBridgePromise !== "undefined") {
+      return await window.shiguangBridgePromise.showAlert(
         title,
         content,
         confirmText,
@@ -181,7 +181,7 @@
       { number: 11, startTime: "20:25", endTime: "21:10" },
       { number: 12, startTime: "21:20", endTime: "22:05" },
     ];
-    await window.AndroidBridgePromise.savePresetTimeSlots(
+    await window.shiguangBridgePromise.savePresetTimeSlots(
       JSON.stringify(timeSlots),
     );
   }
@@ -199,7 +199,7 @@
       defaultBreakDuration: 10,
       firstDayOfWeek: 1,
     };
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
   }
 
   // ---------- 主流程 ----------
@@ -220,7 +220,7 @@
       if (courses.length === 0) throw new Error("未解析到任何课程");
 
       showToast(`解析到 ${courses.length} 门课程，正在保存...`);
-      await window.AndroidBridgePromise.saveImportedCourses(
+      await window.shiguangBridgePromise.saveImportedCourses(
         JSON.stringify(courses),
       );
 
@@ -229,10 +229,10 @@
 
       showToast(`导入完成！共 ${courses.length} 门课程`);
       if (
-        typeof AndroidBridge !== "undefined" &&
-        AndroidBridge.notifyTaskCompletion
+        typeof window.shiguangBridge !== "undefined" &&
+        window.shiguangBridge.notifyTaskCompletion
       ) {
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
       }
     } catch (error) {
       console.error(error);

--- a/resources/CUIT/cuit_bk_old.js
+++ b/resources/CUIT/cuit_bk_old.js
@@ -247,8 +247,8 @@
 
     // ==================== 主导入流程 ====================
     async function runImportFlow() {
-        if (!window.AndroidBridgePromise) throw new Error("AndroidBridgePromise 不可用");
-        AndroidBridge.showToast("正在探测教务参数...");
+        if (!window.shiguangBridgePromise) throw new Error("AndroidBridgePromise 不可用");
+        window.shiguangBridge.showToast("正在探测教务参数...");
 
         const entryHtml = await requestText(`${BASE}/eams/courseTableForStd.action?&sf_request_type=ajax`, {
             method: "GET",
@@ -256,7 +256,7 @@
         });
         const params = parseEntryParams(entryHtml);
         if (!params.studentId || !params.tagId) {
-            await window.AndroidBridgePromise.showAlert("参数探测失败", "未能识别学生ID或学期组件", "确定");
+            await window.shiguangBridgePromise.showAlert("参数探测失败", "未能识别学生ID或学期组件", "确定");
             return;
         }
 
@@ -268,17 +268,17 @@
         const allSemesters = parseSemesterResponse(semesterRaw);
         if (allSemesters.length === 0) throw new Error("学期列表为空");
         const recentSemesters = allSemesters.slice(-8);
-        const selectIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择导入学期",
             JSON.stringify(recentSemesters.map(s => s.name || s.id)),
             recentSemesters.length - 1
         );
         if (selectIndex === null) {
-            AndroidBridge.showToast("已取消导入");
+            window.shiguangBridge.showToast("已取消导入");
             return;
         }
         const selectedSemester = recentSemesters[selectIndex];
-        AndroidBridge.showToast("正在获取课表数据...");
+        window.shiguangBridge.showToast("正在获取课表数据...");
 
         const courseHtml = await requestText(`${BASE}/eams/courseTableForStd!courseTable.action?sf_request_type=ajax`, {
             method: "POST",
@@ -294,16 +294,16 @@
 
         const courses = parseCoursesFromHtml(courseHtml);
         if (courses.length === 0) {
-            await window.AndroidBridgePromise.showAlert("解析失败", "未提取到课程数据", "确定");
+            await window.shiguangBridgePromise.showAlert("解析失败", "未提取到课程数据", "确定");
             return;
         }
 
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程`);
 
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(getPresetTimeSlots()));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(getPresetTimeSlots()));
 
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     }
 
     (async function bootstrap() {
@@ -311,7 +311,7 @@
             await runImportFlow();
         } catch (error) {
             console.error("导入流程失败:", error);
-            AndroidBridge.showToast("导入失败: " + error.message);
+            window.shiguangBridge.showToast("导入失败: " + error.message);
         }
     })();
 })();

--- a/resources/CUP/cup_01.js
+++ b/resources/CUP/cup_01.js
@@ -4,23 +4,23 @@
 async function promptUserToStart() {
     try {
         console.log("即将显示公告弹窗...");
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "重要通知",
             "导入前请确保您已成功登录教务系统，并选定正确的学期。",
             "好的，开始"
         );
         if (confirmed) {
             console.log("用户点击了确认按钮。Alert Promise Resolved: " + confirmed);
-            AndroidBridge.showToast("Alert：用户点击了确认！");
+            window.shiguangBridge.showToast("Alert：用户点击了确认！");
             return true; // 成功时返回 true
         } else {
             console.log("用户点击了取消按钮或关闭了弹窗。Alert Promise Resolved: " + confirmed);
-            AndroidBridge.showToast("Alert：用户取消了！");
+            window.shiguangBridge.showToast("Alert：用户取消了！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
         console.error("显示公告弹窗时发生错误:", error);
-        AndroidBridge.showToast("Alert：显示弹窗出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：显示弹窗出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
@@ -53,7 +53,7 @@ async function getSemesterIndex() {
         const semesterValues = validOptions.map(opt => opt.value); // 例: ["191", "171", ...]
 
         // 4. 调用安卓原生弹窗，让用户选择
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "选择学期", 
             JSON.stringify(semesterTexts), // 必须是 JSON 字符串
             0 // 默认选中第一个（通常是最新学期）
@@ -63,8 +63,8 @@ async function getSemesterIndex() {
         if (selectedIndex !== null && selectedIndex >= 0) {
             // 根据选中的索引，获取对应的学期 ID (value)
             const selectedValue = semesterValues[selectedIndex];
-            if (typeof AndroidBridge !== 'undefined' && AndroidBridge.showToast) {
-                AndroidBridge.showToast("已选择学期: " + semesterTexts[selectedIndex]);
+            if (typeof window.shiguangBridge !== 'undefined' && window.shiguangBridge.showToast) {
+                window.shiguangBridge.showToast("已选择学期: " + semesterTexts[selectedIndex]);
             }
             return selectedValue; // 成功时返回学期编号 (例如 "191")
         } else {
@@ -74,7 +74,7 @@ async function getSemesterIndex() {
         }
     } catch (error) {
         console.error("获取学期信息时发生错误:", error);
-        AndroidBridge.showToast("Alert：获取学期信息出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：获取学期信息出错！" + error.message);
         return null; // 出现错误时返回 null
     }    
 }
@@ -90,7 +90,7 @@ async function fetchPrintData(semesterIndex) {
         return printData;
     } catch (error) {
         console.error("获取数据时发生错误:", error);
-        AndroidBridge.showToast("Alert：获取数据出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：获取数据出错！" + error.message);
         return null;
     }
 }
@@ -116,17 +116,17 @@ async function parseCourses(printData) {
 
     try {
         console.log("正在尝试导入课程...");
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         if (result === true) {
             console.log("课程导入成功！");
-            AndroidBridge.showToast("测试课程导入成功！");
+            window.shiguangBridge.showToast("测试课程导入成功！");
         } else {
             console.log("课程导入未成功，结果：" + result);
-            AndroidBridge.showToast("测试课程导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试课程导入失败，请查看日志。");
         }
     } catch (error) {
         console.error("导入课程时发生错误:", error);
-        AndroidBridge.showToast("导入课程失败: " + error.message);
+        window.shiguangBridge.showToast("导入课程失败: " + error.message);
     }
 }
 
@@ -152,18 +152,18 @@ async function importPresetTimeSlots(printData) {
     
     try {
         console.log("正在尝试导入预设时间段...");
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
             console.log("预设时间段导入成功！");
-            window.AndroidBridge.showToast("测试时间段导入成功！");
+            window.shiguangBridge.showToast("测试时间段导入成功！");
         } else {
             console.log("预设时间段导入未成功，结果：" + result);
-            window.AndroidBridge.showToast("测试时间段导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试时间段导入失败，请查看日志。");
         }
         return result; // 返回导入结果，供流程控制使用
     } catch (error) {
         console.error("导入时间段时发生错误:", error);
-        window.AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
     }
 }
 
@@ -193,19 +193,19 @@ async function saveConfig(semesterIndex) {
         console.log("正在尝试导入课表配置...");
         const configJsonString = JSON.stringify(courseConfigData);
 
-        const result = await window.AndroidBridgePromise.saveCourseConfig(configJsonString);
+        const result = await window.shiguangBridgePromise.saveCourseConfig(configJsonString);
 
         if (result === true) {
             console.log("课表配置导入成功！");
-            AndroidBridge.showToast("测试配置导入成功！开学日期: " + startDate.toISOString().split('T')[0]);
+            window.shiguangBridge.showToast("测试配置导入成功！开学日期: " + startDate.toISOString().split('T')[0]);
         } else {
             console.log("课表配置导入未成功，结果：" + result);
-            AndroidBridge.showToast("测试配置导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试配置导入失败，请查看日志。");
         }
         return result; // 返回导入结果，供流程控制使用
     } catch (error) {
         console.error("导入配置时发生错误:", error);
-        AndroidBridge.showToast("导入配置失败: " + error.message);
+        window.shiguangBridge.showToast("导入配置失败: " + error.message);
     }
 }
 
@@ -215,7 +215,7 @@ async function saveConfig(semesterIndex) {
  * 在任何一步用户取消或发生错误时，都会立即退出，AndroidBridge.notifyTaskCompletion()应该只在成功后调用  
  */
 async function runImportFlow() {
-    AndroidBridge.showToast("课程导入流程即将开始...");
+    window.shiguangBridge.showToast("课程导入流程即将开始...");
 
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
@@ -226,7 +226,7 @@ async function runImportFlow() {
     // 2. 获取学期。
     const semesterIndex = await getSemesterIndex();
     if (semesterIndex === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         // 用户取消，直接退出
         return;
     }
@@ -234,7 +234,7 @@ async function runImportFlow() {
     // 3. 获取课程数据
     const printData = await fetchPrintData(semesterIndex);
     if (printData === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         // 请求失败或无数据，直接退出
         return;
     }
@@ -261,8 +261,8 @@ async function runImportFlow() {
     }
 
     // 7. 流程**完全成功**，发送结束信号。
-    AndroidBridge.showToast("所有任务已完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动所有演示

--- a/resources/CUP/cup_02.js
+++ b/resources/CUP/cup_02.js
@@ -77,7 +77,7 @@ function validateDateInput(input) {
 // 1. 显示一个公告信息弹窗
 async function promptUserToStart() {
     console.log("即将显示公告弹窗...");
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "重要通知",
         "导入前请确保您已成功登录教务系统，并选定正确的学期。",
         "好的，开始"
@@ -90,7 +90,7 @@ async function selectCampus() {
     // 从配置中提取用于展示的名称数组
     const campusLabels = CAMPUS_OPTIONS.map(opt => opt.label);
     
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择所在校区", 
         JSON.stringify(campusLabels), 
         0 
@@ -141,7 +141,7 @@ async function getTermCode() {
         }
     });
 
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择导入学期", 
         JSON.stringify(semesterTexts), 
         defaultSelectedIndex
@@ -292,7 +292,7 @@ async function parseCourses(py_kbcx_ew, isKaramayCampus) {   
         return c;
     });
 
-    const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+    const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
     if (result !== true) {
         throw new Error("课程导入失败，请查看日志。");
     }
@@ -352,7 +352,7 @@ async function importPresetTimeSlots(campusId) {   
         }
     });
 
-    const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(generatedSlots));
+    const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(generatedSlots));
     if (result !== true) {
         throw new Error("时间段导入失败，请查看日志。");
     }
@@ -361,7 +361,7 @@ async function importPresetTimeSlots(campusId) {   
 
 // 7. 导入课表配置
 async function saveConfig() {
-    let startDate = await window.AndroidBridgePromise.showPrompt(
+    let startDate = await window.shiguangBridgePromise.showPrompt(
         "输入开学日期", 
         "请输入本学期开学日期 (格式: YYYY-MM-DD):",
         "2025-09-01",          
@@ -383,7 +383,7 @@ async function saveConfig() {
     };
 
     const configJsonString = JSON.stringify(courseConfigData);
-    const result = await window.AndroidBridgePromise.saveCourseConfig(configJsonString);
+    const result = await window.shiguangBridgePromise.saveCourseConfig(configJsonString);
     if (result !== true) {
         throw new Error("导入配置失败，请查看日志。");
     }
@@ -428,11 +428,11 @@ async function runImportFlow() {
         await saveConfig();
 
         // 8. 流程**完全成功**，发送结束信号。
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
         const message = error && error.message ? error.message : "导入流程执行失败。";
-        if (typeof AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast(message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast(message);
         }
         console.error("runImportFlow error:", error);
     }

--- a/resources/CUPK/cupk_01.js
+++ b/resources/CUPK/cupk_01.js
@@ -8,23 +8,23 @@
 async function promptUserToStart() {
     try {
         console.log("即将显示公告弹窗...");
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "重要通知",
             "导入前请确保您已成功登录教务系统，并选定正确的学期。",
             "好的，开始"
         );
         if (confirmed) {
             console.log("用户点击了确认按钮。Alert Promise Resolved: " + confirmed);
-            AndroidBridge.showToast("Alert：用户点击了确认！");
+            window.shiguangBridge.showToast("Alert：用户点击了确认！");
             return true; // 成功时返回 true
         } else {
             console.log("用户点击了取消按钮或关闭了弹窗。Alert Promise Resolved: " + confirmed);
-            AndroidBridge.showToast("Alert：用户取消了！");
+            window.shiguangBridge.showToast("Alert：用户取消了！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
         console.error("显示公告弹窗时发生错误:", error);
-        AndroidBridge.showToast("Alert：显示弹窗出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：显示弹窗出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
@@ -57,7 +57,7 @@ async function getSemesterIndex() {
         const semesterValues = validOptions.map(opt => opt.value); // 例: ["191", "171", ...]
 
         // 4. 调用安卓原生弹窗，让用户选择
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "选择学期", 
             JSON.stringify(semesterTexts), // 必须是 JSON 字符串
             0 // 默认选中第一个（通常是最新学期）
@@ -67,8 +67,8 @@ async function getSemesterIndex() {
         if (selectedIndex !== null && selectedIndex >= 0) {
             // 根据选中的索引，获取对应的学期 ID (value)
             const selectedValue = semesterValues[selectedIndex];
-            if (typeof AndroidBridge !== 'undefined' && AndroidBridge.showToast) {
-                AndroidBridge.showToast("已选择学期: " + semesterTexts[selectedIndex]);
+            if (typeof window.shiguangBridge !== 'undefined' && window.shiguangBridge.showToast) {
+                window.shiguangBridge.showToast("已选择学期: " + semesterTexts[selectedIndex]);
             }
             return selectedValue; // 成功时返回学期编号 (例如 "191")
         } else {
@@ -78,7 +78,7 @@ async function getSemesterIndex() {
         }
     } catch (error) {
         console.error("获取学期信息时发生错误:", error);
-        AndroidBridge.showToast("Alert：获取学期信息出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：获取学期信息出错！" + error.message);
         return null; // 出现错误时返回 null
     }    
 }
@@ -94,7 +94,7 @@ async function fetchPrintData(semesterIndex) {
         return printData;
     } catch (error) {
         console.error("获取数据时发生错误:", error);
-        AndroidBridge.showToast("Alert：获取数据出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：获取数据出错！" + error.message);
         return null;
     }
 }
@@ -120,17 +120,17 @@ async function parseCourses(printData) {
 
     try {
         console.log("正在尝试导入课程...");
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         if (result === true) {
             console.log("课程导入成功！");
-            AndroidBridge.showToast("测试课程导入成功！");
+            window.shiguangBridge.showToast("测试课程导入成功！");
         } else {
             console.log("课程导入未成功，结果：" + result);
-            AndroidBridge.showToast("测试课程导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试课程导入失败，请查看日志。");
         }
     } catch (error) {
         console.error("导入课程时发生错误:", error);
-        AndroidBridge.showToast("导入课程失败: " + error.message);
+        window.shiguangBridge.showToast("导入课程失败: " + error.message);
     }
 }
 
@@ -156,18 +156,18 @@ async function importPresetTimeSlots(printData) {
     
     try {
         console.log("正在尝试导入预设时间段...");
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
             console.log("预设时间段导入成功！");
-            window.AndroidBridge.showToast("测试时间段导入成功！");
+            window.shiguangBridge.showToast("测试时间段导入成功！");
         } else {
             console.log("预设时间段导入未成功，结果：" + result);
-            window.AndroidBridge.showToast("测试时间段导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试时间段导入失败，请查看日志。");
         }
         return result; // 返回导入结果，供流程控制使用
     } catch (error) {
         console.error("导入时间段时发生错误:", error);
-        window.AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
     }
 }
 
@@ -197,19 +197,19 @@ async function saveConfig(semesterIndex) {
         console.log("正在尝试导入课表配置...");
         const configJsonString = JSON.stringify(courseConfigData);
 
-        const result = await window.AndroidBridgePromise.saveCourseConfig(configJsonString);
+        const result = await window.shiguangBridgePromise.saveCourseConfig(configJsonString);
 
         if (result === true) {
             console.log("课表配置导入成功！");
-            AndroidBridge.showToast("测试配置导入成功！开学日期: " + startDate.toISOString().split('T')[0]);
+            window.shiguangBridge.showToast("测试配置导入成功！开学日期: " + startDate.toISOString().split('T')[0]);
         } else {
             console.log("课表配置导入未成功，结果：" + result);
-            AndroidBridge.showToast("测试配置导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试配置导入失败，请查看日志。");
         }
         return result; // 返回导入结果，供流程控制使用
     } catch (error) {
         console.error("导入配置时发生错误:", error);
-        AndroidBridge.showToast("导入配置失败: " + error.message);
+        window.shiguangBridge.showToast("导入配置失败: " + error.message);
     }
 }
 
@@ -219,7 +219,7 @@ async function saveConfig(semesterIndex) {
  * 在任何一步用户取消或发生错误时，都会立即退出，AndroidBridge.notifyTaskCompletion()应该只在成功后调用  
  */
 async function runImportFlow() {
-    AndroidBridge.showToast("课程导入流程即将开始...");
+    window.shiguangBridge.showToast("课程导入流程即将开始...");
 
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
@@ -230,7 +230,7 @@ async function runImportFlow() {
     // 2. 获取学期。
     const semesterIndex = await getSemesterIndex();
     if (semesterIndex === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         // 用户取消，直接退出
         return;
     }
@@ -238,7 +238,7 @@ async function runImportFlow() {
     // 3. 获取课程数据
     const printData = await fetchPrintData(semesterIndex);
     if (printData === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         // 请求失败或无数据，直接退出
         return;
     }
@@ -265,8 +265,8 @@ async function runImportFlow() {
     }
 
     // 7. 流程**完全成功**，发送结束信号。
-    AndroidBridge.showToast("所有任务已完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动所有演示

--- a/resources/CUST/cust.js
+++ b/resources/CUST/cust.js
@@ -182,7 +182,7 @@ async function fetchScheduleData() {
 
     } catch (error) {
         console.error('获取课表数据失败:', error);
-        AndroidBridge.showToast('获取课表失败: ' + error.message);
+        window.shiguangBridge.showToast('获取课表失败: ' + error.message);
         return null;
     }
 }
@@ -226,7 +226,7 @@ function generateTimeSlots(timeSlotsFromAPI) {
 async function importCourseSchedule() {
     try {
         console.log('开始导入课程表...');
-        AndroidBridge.showToast('正在获取课表数据...');
+        window.shiguangBridge.showToast('正在获取课表数据...');
 
         // 获取课表数据
         const scheduleData = await fetchScheduleData();
@@ -238,7 +238,7 @@ async function importCourseSchedule() {
         const { courses, timeSlots } = convertScheduleData(scheduleData);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast('未找到课程数据');
+            window.shiguangBridge.showToast('未找到课程数据');
             return false;
         }
 
@@ -246,13 +246,13 @@ async function importCourseSchedule() {
         console.log('课程数据:', courses);
 
         // 导入课程
-        const coursesResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const coursesResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (coursesResult === true) {
             console.log('课程导入成功！');
-            AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
         } else {
             console.log('课程导入失败');
-            AndroidBridge.showToast('课程导入失败');
+            window.shiguangBridge.showToast('课程导入失败');
             return false;
         }
 
@@ -260,20 +260,20 @@ async function importCourseSchedule() {
         const finalTimeSlots = generateTimeSlots(timeSlots);
         console.log('时间段配置:', finalTimeSlots);
 
-        const timeSlotsResult = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(finalTimeSlots));
+        const timeSlotsResult = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(finalTimeSlots));
         if (timeSlotsResult === true) {
             console.log('时间段导入成功！');
-            AndroidBridge.showToast('时间段配置成功！');
+            window.shiguangBridge.showToast('时间段配置成功！');
         } else {
             console.log('时间段导入失败');
-            AndroidBridge.showToast('时间段配置失败');
+            window.shiguangBridge.showToast('时间段配置失败');
         }
 
         return true;
 
     } catch (error) {
         console.error('导入过程出错:', error);
-        AndroidBridge.showToast('导入失败: ' + error.message);
+        window.shiguangBridge.showToast('导入失败: ' + error.message);
         return false;
     }
 }
@@ -284,23 +284,23 @@ async function importCourseSchedule() {
 async function demoAlert() {
     try {
         console.log("即将显示公告弹窗...");
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "重要通知",
             "这是一个弹窗示例。",
             "好的"
         );
         if (confirmed) {
             console.log("用户点击了确认按钮。Alert Promise Resolved: " + confirmed);
-            AndroidBridge.showToast("Alert：用户点击了确认！");
+            window.shiguangBridge.showToast("Alert：用户点击了确认！");
             return true; // 成功时返回 true
         } else {
             console.log("用户点击了取消按钮或关闭了弹窗。Alert Promise Resolved: " + confirmed);
-            AndroidBridge.showToast("Alert：用户取消了！");
+            window.shiguangBridge.showToast("Alert：用户取消了！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
         console.error("显示公告弹窗时发生错误:", error);
-        AndroidBridge.showToast("Alert：显示弹窗出错！" + error.message);
+        window.shiguangBridge.showToast("Alert：显示弹窗出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
@@ -319,7 +319,7 @@ function validateName(name) {
 async function demoPrompt() {
     try {
         console.log("即将显示输入框弹窗...");
-        const name = await window.AndroidBridgePromise.showPrompt(
+        const name = await window.shiguangBridgePromise.showPrompt(
             "输入你的姓名",
             "请输入至少2个字符",
             "测试用户",
@@ -327,16 +327,16 @@ async function demoPrompt() {
         );
         if (name !== null) {
             console.log("用户输入的姓名是: " + name);
-            AndroidBridge.showToast("欢迎你，" + name + "！");
+            window.shiguangBridge.showToast("欢迎你，" + name + "！");
             return true; // 成功时返回 true
         } else {
             console.log("用户取消了输入。");
-            AndroidBridge.showToast("Prompt：用户取消了输入！");
+            window.shiguangBridge.showToast("Prompt：用户取消了输入！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
         console.error("显示输入框弹窗时发生错误:", error);
-        AndroidBridge.showToast("Prompt：显示输入框出错！" + error.message);
+        window.shiguangBridge.showToast("Prompt：显示输入框出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
@@ -346,29 +346,29 @@ async function demoSingleSelection() {
     const fruits = ["苹果", "香蕉", "橙子", "葡萄", "西瓜", "芒果"];
     try {
         console.log("即将显示单选列表弹窗...");
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "选择你喜欢的水果",
             JSON.stringify(fruits),
             2
         );
         if (selectedIndex !== null && selectedIndex >= 0 && selectedIndex < fruits.length) {
             console.log("用户选择了: " + fruits[selectedIndex] + " (索引: " + selectedIndex + ")");
-            AndroidBridge.showToast("你选择了 " + fruits[selectedIndex]);
+            window.shiguangBridge.showToast("你选择了 " + fruits[selectedIndex]);
             return true; // 成功时返回 true
         } else {
             console.log("用户取消了选择。");
-            AndroidBridge.showToast("Single Selection：用户取消了选择！");
+            window.shiguangBridge.showToast("Single Selection：用户取消了选择！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
         console.error("显示单选列表弹窗时发生错误:", error);
-        AndroidBridge.showToast("Single Selection：显示列表出错！" + error.message);
+        window.shiguangBridge.showToast("Single Selection：显示列表出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
 
 // 仍然可以使用原始的 AndroidBridge 对象
-AndroidBridge.showToast("这是一个来自 JS 的 Toast 消息，会很快消失！");
+window.shiguangBridge.showToast("这是一个来自 JS 的 Toast 消息，会很快消失！");
 
 async function demoSaveCourses() {
     // ... 代码保持不变 ...
@@ -558,17 +558,17 @@ async function demoSaveCourses() {
 
     try {
         console.log("正在尝试导入课程...");
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(testCourses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(testCourses));
         if (result === true) {
             console.log("课程导入成功！");
-            AndroidBridge.showToast("测试课程导入成功！");
+            window.shiguangBridge.showToast("测试课程导入成功！");
         } else {
             console.log("课程导入未成功，结果：" + result);
-            AndroidBridge.showToast("测试课程导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试课程导入失败，请查看日志。");
         }
     } catch (error) {
         console.error("导入课程时发生错误:", error);
-        AndroidBridge.showToast("导入课程失败: " + error.message);
+        window.shiguangBridge.showToast("导入课程失败: " + error.message);
     }
 }
 
@@ -596,17 +596,17 @@ async function importPresetTimeSlots() {
 
     try {
         console.log("正在尝试导入预设时间段...");
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
             console.log("预设时间段导入成功！");
-            window.AndroidBridge.showToast("测试时间段导入成功！");
+            window.shiguangBridge.showToast("测试时间段导入成功！");
         } else {
             console.log("预设时间段导入未成功，结果：" + result);
-            window.AndroidBridge.showToast("测试时间段导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试时间段导入失败，请查看日志。");
         }
     } catch (error) {
         console.error("导入时间段时发生错误:", error);
-        window.AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
     }
 }
 
@@ -614,7 +614,7 @@ async function importPresetTimeSlots() {
  * 编排这些异步操作，并在用户取消时停止后续执行。
  */
 async function runAllDemosSequentially() {
-    AndroidBridge.showToast("所有演示将按顺序开始...");
+    window.shiguangBridge.showToast("所有演示将按顺序开始...");
 
     // 1. 运行第一个演示：Alert
     const alertResult = await demoAlert();
@@ -638,14 +638,14 @@ async function runAllDemosSequentially() {
     }
 
     console.log("所有弹窗演示已完成。");
-    AndroidBridge.showToast("所有弹窗演示已完成！");
+    window.shiguangBridge.showToast("所有弹窗演示已完成！");
 
     // 以下是数据导入，与用户交互无关，可以继续
     await demoSaveCourses();
     await importPresetTimeSlots();
 
     // 发送最终的生命周期完成信号
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // ========== 主执行逻辑 ==========
@@ -653,19 +653,19 @@ async function runAllDemosSequentially() {
 // 检查页面并执行相应操作
 if (isOnStudentPage()) {
     console.log('检测到在长春理工大学教务系统学生页面');
-    AndroidBridge.showToast('正在准备导入课程表...');
+    window.shiguangBridge.showToast('正在准备导入课程表...');
 
     // 延迟一秒确保页面加载完成
     setTimeout(async () => {
         const success = await importCourseSchedule();
         if (success) {
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.notifyTaskCompletion();
         }
     }, 1000);
 
 } else {
     console.log('当前不在教务系统页面，运行演示模式');
-    AndroidBridge.showToast('请先登录教务系统！');
+    window.shiguangBridge.showToast('请先登录教务系统！');
 
     // 可选：运行演示
     const runDemo = false; // 设为true可以运行演示

--- a/resources/CWXU/cwxu_01.js
+++ b/resources/CWXU/cwxu_01.js
@@ -134,7 +134,7 @@ function getDefaultAcademicYear() {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "无锡学院课表导入",
         "请先登录无锡学院教务系统。登录成功后可在教务系统任意页面开始导入。",
         "开始导入"
@@ -142,7 +142,7 @@ async function promptUserToStart() {
 }
 
 async function getAcademicYear() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入学年的起始年份，例如 2025-2026 学年请输入 2025。",
         getDefaultAcademicYear(),
@@ -151,7 +151,7 @@ async function getAcademicYear() {
 }
 
 async function selectSemester() {
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(["第一学期", "第二学期"]),
         0
@@ -163,7 +163,7 @@ function getSemesterCode(semesterIndex) {
 }
 
 async function fetchCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
 
     const requestBody = new URLSearchParams({
         xnm: academicYear,
@@ -216,47 +216,47 @@ async function fetchCourses(academicYear, semesterIndex) {
 
 async function saveCourses(courses) {
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         return true;
     } catch (error) {
         console.error("CWXU: Save courses error", error);
-        await window.AndroidBridgePromise.showAlert("保存失败", `课程保存失败：${error.message}`, "确定");
+        await window.shiguangBridgePromise.showAlert("保存失败", `课程保存失败：${error.message}`, "确定");
         return false;
     }
 }
 
 async function saveOptionalSettings(config) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     } catch (error) {
         console.error("CWXU: Save config error", error);
-        AndroidBridge.showToast(`课表配置保存失败：${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败：${error.message}`);
     }
 
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
     } catch (error) {
         console.error("CWXU: Save time slots error", error);
-        AndroidBridge.showToast(`作息时间保存失败：${error.message}`);
+        window.shiguangBridge.showToast(`作息时间保存失败：${error.message}`);
     }
 }
 
 async function runImportFlow() {
     const confirmed = await promptUserToStart();
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex < 0) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -265,7 +265,7 @@ async function runImportFlow() {
         result = await fetchCourses(String(academicYear).trim(), semesterIndex);
     } catch (error) {
         console.error("CWXU: Fetch or parse error", error);
-        await window.AndroidBridgePromise.showAlert("导入失败", error.message, "确定");
+        await window.shiguangBridgePromise.showAlert("导入失败", error.message, "确定");
         return;
     }
 
@@ -273,8 +273,8 @@ async function runImportFlow() {
     if (!saved) return;
 
     await saveOptionalSettings(result.config);
-    AndroidBridge.showToast(`课程导入成功，共导入 ${result.courses.length} 条课程安排。`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${result.courses.length} 条课程安排。`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/CZIMT/czimt.js
+++ b/resources/CZIMT/czimt.js
@@ -109,7 +109,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "常机电学生课表导入",
         "导入前请确保您已成功登录教务系统。",
         "开始导入"
@@ -118,7 +118,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2026-2027 应输入 2026）:",
         currentYear,
@@ -128,7 +128,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期", "第三学期(短学期)"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -181,19 +181,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             console.error(`Entry failed: ${url}`);
         }
     }
-    AndroidBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);A
         return false;
     }
@@ -218,17 +218,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -236,20 +236,20 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     console.log(`JS: 已选择学年: ${academicYear}`);
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     console.log(`JS: 已选择学期索引: ${semesterIndex}`);
@@ -275,15 +275,15 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
     }
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/DLMU/dlmu_01.js
+++ b/resources/DLMU/dlmu_01.js
@@ -388,7 +388,7 @@ async function fetchCourseTableData(semesterId, ids) {
  * @returns {Promise<boolean>} 用户是否确认
  */
 async function promptUserToStart() {
-  return await window.AndroidBridgePromise.showAlert(
+  return await window.shiguangBridgePromise.showAlert(
     "重要提醒",
     "请确保您已登录服务大厅，并进入海大教务系统内的任意页面(不用点开课表)。\n值得注意的是，教务课表与海大在线的课表并非完全同步，若后期学校调课不规范，可能导致教务课表滞后。\n\n点击确定继续。",
     "确定",
@@ -400,7 +400,7 @@ async function promptUserToStart() {
  * @returns {Promise<string|null>} 用户输入的年份，取消返回null
  */
 async function getAcademicYear() {
-  return await window.AndroidBridgePromise.showPrompt(
+  return await window.shiguangBridgePromise.showPrompt(
     "学年设置",
     "请输入本学年开始的年份\n（例如 2024，代表 2024-2025 学年）",
     "2024",
@@ -414,7 +414,7 @@ async function getAcademicYear() {
  */
 async function selectSemester() {
   const semesterOptions = ["上学期", "下学期", "小学期"];
-  const index = await window.AndroidBridgePromise.showSingleSelection(
+  const index = await window.shiguangBridgePromise.showSingleSelection(
     "选择学期",
     JSON.stringify(semesterOptions),
     0,
@@ -435,19 +435,19 @@ async function run() {
     // 1. 公告
     const confirmed = await promptUserToStart();
     if (!confirmed) {
-      AndroidBridge.showToast("用户取消了导入流程。");
+      window.shiguangBridge.showToast("用户取消了导入流程。");
       return;
     }
 
     // 2. 获取学年
     const yearInput = await getAcademicYear();
     if (yearInput === null) {
-      AndroidBridge.showToast("导入已取消。");
+      window.shiguangBridge.showToast("导入已取消。");
       return;
     }
     const yearNum = parseInt(yearInput);
     if (isNaN(yearNum) || yearNum <= 2000 || yearNum > 2100) {
-      await window.AndroidBridgePromise.showAlert(
+      await window.shiguangBridgePromise.showAlert(
         "错误",
         "学年输入无效，请输入2001-2100之间的数字。",
         "确定",
@@ -459,7 +459,7 @@ async function run() {
     // 3. 获取学期
     const semesterIndex = await selectSemester();
     if (semesterIndex === null) {
-      AndroidBridge.showToast("导入已取消。");
+      window.shiguangBridge.showToast("导入已取消。");
       return;
     }
     const termCode =
@@ -468,14 +468,14 @@ async function run() {
     const semesterId = parseSemesterId(semesterHtml, schoolYear, termCode);
 
     // 4. 请求课表
-    AndroidBridge.showToast("正在获取课表，请稍候...");
+    window.shiguangBridge.showToast("正在获取课表，请稍候...");
     let courseTableDataHtml = "";
     try {
       const idsHtml = await fetchCourseTableForStd();
       const ids = parseStudentIds(idsHtml);
       courseTableDataHtml = await fetchCourseTableData(semesterId, ids);
     } catch (fetchErr) {
-      await window.AndroidBridgePromise.showAlert(
+      await window.shiguangBridgePromise.showAlert(
         "网络请求失败",
         `请求教务系统失败：${fetchErr.message}\n\n请检查网络连接和登录状态。`,
         "确定",
@@ -484,7 +484,7 @@ async function run() {
     }
 
     if (!courseTableDataHtml.length) {
-      await window.AndroidBridgePromise.showAlert(
+      await window.shiguangBridgePromise.showAlert(
         "提示",
         "未获取到任何课程数据。请确认已登录教务系统并选择正确的学年学期。",
         "确定",
@@ -497,14 +497,14 @@ async function run() {
 
     // 6. 保存课程
     try {
-      await window.AndroidBridgePromise.saveImportedCourses(
+      await window.shiguangBridgePromise.saveImportedCourses(
         JSON.stringify(targetCourses),
       );
-      AndroidBridge.showToast(
+      window.shiguangBridge.showToast(
         `课程数据已导入（共 ${targetCourses.length} 条）`,
       );
     } catch (saveErr) {
-      await window.AndroidBridgePromise.showAlert(
+      await window.shiguangBridgePromise.showAlert(
         "保存课程失败",
         saveErr.message,
         "确定",
@@ -515,28 +515,28 @@ async function run() {
     // 7. 保存时间段
     const timeSlots = getTimeSlots();
     try {
-      await window.AndroidBridgePromise.savePresetTimeSlots(
+      await window.shiguangBridgePromise.savePresetTimeSlots(
         JSON.stringify(timeSlots),
       );
-      AndroidBridge.showToast("时间段数据已导入");
+      window.shiguangBridge.showToast("时间段数据已导入");
     } catch (slotErr) {
       // 时间段保存失败不终止流程，只提示
-      AndroidBridge.showToast(`时间段保存失败：${slotErr.message}`);
+      window.shiguangBridge.showToast(`时间段保存失败：${slotErr.message}`);
     }
 
     // 8. 完成通知
-    AndroidBridge.showToast("导入完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("导入完成！");
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (err) {
     // 捕获所有未预料的错误
     console.error("run error:", err);
-    await window.AndroidBridgePromise.showAlert(
+    await window.shiguangBridgePromise.showAlert(
       "导入失败",
       `未知错误：${err.message || err}\n\n请联系开发者。`,
       "确定",
     );
     // 仍然通知完成，但可能不会生成有效文件
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
   }
 }
 

--- a/resources/DLU/dlu.js
+++ b/resources/DLU/dlu.js
@@ -111,7 +111,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "大连大学教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -122,7 +122,7 @@ async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     const currentMonth = new Date().getMonth() + 1; 
     const defaultYear = currentMonth >= 8 ? currentYear : (Number(currentYear) - 1).toString(); 
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（如2023-2024 应该填2023）:",
         defaultYear,
@@ -134,7 +134,7 @@ async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     const currentMonth = new Date().getMonth() + 1; 
     const defaultSemesterIndex = currentMonth >= 8 ? 0 : 1; 
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         defaultSemesterIndex
@@ -154,7 +154,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
 
@@ -187,32 +187,32 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         try {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
             return null;
         }
 
         return { courses: courses };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         return false;
     }
 }
@@ -272,12 +272,12 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
@@ -291,19 +291,19 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -324,8 +324,8 @@ async function runImportFlow() {
     // 导入预设作息时间
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast(`课程及作息时间导入成功，共导入 ${courses.length} 门课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程及作息时间导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/ECJTU/ecjtu_01.js
+++ b/resources/ECJTU/ecjtu_01.js
@@ -236,7 +236,7 @@ async function loadScheduleDoc() {
 
 async function runImportFlow() {
   try {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
       '华东交通大学教务导入',
       '请确认你已经登录教务系统；如需导入其他学期，请先在页面上切换到目标学期后再导入。',
       '确定，开始导入'
@@ -245,7 +245,7 @@ async function runImportFlow() {
 
     const doc = await loadScheduleDoc();
     const termInfo = getCurrentTermInfo(doc);
-    AndroidBridge.showToast(termInfo?.text ? `正在导入 ${termInfo.text} 课表...` : '正在解析课表数据...');
+    window.shiguangBridge.showToast(termInfo?.text ? `正在导入 ${termInfo.text} 课表...` : '正在解析课表数据...');
 
     const courses = parseScheduleTable(doc);
     if (!courses.length) {
@@ -255,19 +255,19 @@ async function runImportFlow() {
     const allWeeks = courses.flatMap(course => course.weeks);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks,
       semesterStartDate: null,
       firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (error) {
     console.error(error);
-    AndroidBridge.showToast(`导入失败: ${error.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${error.message}`);
   }
 }
 

--- a/resources/FJCPC/fjcpc.js
+++ b/resources/FJCPC/fjcpc.js
@@ -4,7 +4,7 @@
 
 // 引导
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "公告",
         "即将开始导入请确保已经登录并跳转到已显示课表位置",
         "好的，开始"
@@ -17,7 +17,7 @@ async function promptUserToStart() {
 async function selectTimeSchedule() {
     const semesters = ["夏季作息", "冬季作息"];
     
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(semesters),
         -1
@@ -62,7 +62,7 @@ async function fetchAndParseData() {
     // 自动提取凭证
     const match = document.cookie.match(/Admin-Token=([^;]+)/);
     if (!match) {
-        AndroidBridge.showToast("未发现登录凭证，请登录后重试");
+        window.shiguangBridge.showToast("未发现登录凭证，请登录后重试");
         return null;
     }
     const token = decodeURIComponent(match[1]);
@@ -129,7 +129,7 @@ async function fetchAndParseData() {
             courses: courses
         };
     } catch (e) {
-        AndroidBridge.showToast("数据解析失败: " + e.message);
+        window.shiguangBridge.showToast("数据解析失败: " + e.message);
         return null;
     }
 }
@@ -137,19 +137,19 @@ async function fetchAndParseData() {
 // 编排主流程
 
 async function runImportFlow() {
-    AndroidBridge.showToast("课程导入流程开始...");
+    window.shiguangBridge.showToast("课程导入流程开始...");
 
     // 公告和前置检查
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     // 选择作息时间
     const timeSlots = await selectTimeSchedule();
     if (timeSlots === null) {
-        AndroidBridge.showToast("已取消选择作息。");
+        window.shiguangBridge.showToast("已取消选择作息。");
         return;
     }
 
@@ -161,31 +161,31 @@ async function runImportFlow() {
 
     // 保存课表配置
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(data.config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(data.config));
     } catch (e) {
-        AndroidBridge.showToast("保存配置失败");
+        window.shiguangBridge.showToast("保存配置失败");
         return;
     }
 
     // 课程数据保存
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(data.courses));
-        AndroidBridge.showToast(`成功抓取 ${data.courses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(data.courses));
+        window.shiguangBridge.showToast(`成功抓取 ${data.courses.length} 门课程！`);
     } catch (e) {
-        AndroidBridge.showToast("保存课程数据失败");
+        window.shiguangBridge.showToast("保存课程数据失败");
         return;
     }
 
     // 导入时间段
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-        AndroidBridge.showToast("作息时间同步成功");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        window.shiguangBridge.showToast("作息时间同步成功");
     } catch (e) {
         console.error("作息保存失败:", e);
     }
 
-    AndroidBridge.showToast("所有任务已完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/FOSU/fosu_01.js
+++ b/resources/FOSU/fosu_01.js
@@ -430,7 +430,7 @@ async function parseAndImportCourses() {
     
     if (!tableElement) {
         console.error('未找到课程表格元素 #kbtable');
-        AndroidBridge.showToast('未找到课程表格，请确保在正确的页面！');
+        window.shiguangBridge.showToast('未找到课程表格，请确保在正确的页面！');
         return false;
     }
     
@@ -446,19 +446,19 @@ async function parseAndImportCourses() {
     console.log('解析结果:', JSON.stringify(courses, null, 2));
     
     try {
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (result === true) {
             console.log('课程导入成功！');
-            AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
             return true;
         } else {
             console.log('课程导入失败，结果：' + result);
-            AndroidBridge.showToast('课程导入失败，请查看日志。');
+            window.shiguangBridge.showToast('课程导入失败，请查看日志。');
             return false;
         }
     } catch (error) {
         console.error('导入课程时发生错误:', error);
-        AndroidBridge.showToast('导入课程失败: ' + error.message);
+        window.shiguangBridge.showToast('导入课程失败: ' + error.message);
         return false;
     }
 }
@@ -484,19 +484,19 @@ async function importPresetTimeSlots() {
 
     try {
         console.log("正在尝试导入预设时间段...");
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
             console.log("预设时间段导入成功！");
-            window.AndroidBridge.showToast("时间段导入成功！");
+            window.shiguangBridge.showToast("时间段导入成功！");
             return true;
         } else {
             console.log("预设时间段导入未成功，结果：" + result);
-            window.AndroidBridge.showToast("时间段导入失败，请查看日志。");
+            window.shiguangBridge.showToast("时间段导入失败，请查看日志。");
             return false;
         }
     } catch (error) {
         console.error("导入时间段时发生错误:", error);
-        window.AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false;
     }
 }
@@ -577,36 +577,36 @@ async function saveCourseConfig() {
         console.log("配置数据:", JSON.stringify(courseConfigData, null, 2));
         const configJsonString = JSON.stringify(courseConfigData);
 
-        const result = await window.AndroidBridgePromise.saveCourseConfig(configJsonString);
+        const result = await window.shiguangBridgePromise.saveCourseConfig(configJsonString);
 
         if (result === true) {
             console.log("课表配置导入成功！");
-            AndroidBridge.showToast(`配置导入成功！学期: ${semesterInfo.semester}, 开学: ${courseConfigData.semesterStartDate}`);
+            window.shiguangBridge.showToast(`配置导入成功！学期: ${semesterInfo.semester}, 开学: ${courseConfigData.semesterStartDate}`);
             return true;
         } else {
             console.log("课表配置导入未成功，结果：" + result);
-            AndroidBridge.showToast("配置导入失败，请查看日志。");
+            window.shiguangBridge.showToast("配置导入失败，请查看日志。");
             return false;
         }
     } catch (error) {
         console.error("导入配置时发生错误:", error);
-        AndroidBridge.showToast("导入配置失败: " + error.message);
+        window.shiguangBridge.showToast("导入配置失败: " + error.message);
         return false;
     }
 }
 
 async function runImportFlow() {
-    const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
         "佛山大学教务系统课表导入",
         "【重要】本系统需要使用校园网访问，请确保已连接校园网后再操作。\n\n导入步骤：\n1. 登录教务系统\n2. 导航到【培养管理】→【学期理论课表】\n3. 确认课表已加载显示\n4. 点击确定开始导入",
         "好的，开始导入"
     );
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
-    AndroidBridge.showToast("开始解析课程表...");
+    window.shiguangBridge.showToast("开始解析课程表...");
 
     console.log("=== 开始课程表解析和导入流程 ===");
 
@@ -617,15 +617,15 @@ async function runImportFlow() {
     }
 
     console.log("课程导入完成。");
-    AndroidBridge.showToast("课程导入完成！");
+    window.shiguangBridge.showToast("课程导入完成！");
 
     await importPresetTimeSlots();
     await saveCourseConfig();
 
     console.log("=== 所有任务完成 ===");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
-if (typeof AndroidBridge !== 'undefined' && AndroidBridge) {
+if (typeof window.shiguangBridge !== 'undefined' && window.shiguangBridge) {
     runImportFlow();
 }

--- a/resources/GDIPU/gdipu.js
+++ b/resources/GDIPU/gdipu.js
@@ -7,7 +7,7 @@ const promptForStartDate = async () => {
         const today = new Date();
         const defaultDate = today.toISOString().split('T')[0];
         
-        const startDate = await window.AndroidBridgePromise.showPrompt(
+        const startDate = await window.shiguangBridgePromise.showPrompt(
             "请输入学期开始日期",
             "格式：YYYY-MM-DD（例如：2026-02-24）",
             defaultDate,
@@ -19,7 +19,7 @@ const promptForStartDate = async () => {
         }
         
         if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
-            AndroidBridge.showToast("日期格式不正确，请使用YYYY-MM-DD格式");
+            window.shiguangBridge.showToast("日期格式不正确，请使用YYYY-MM-DD格式");
             throw new Error("日期格式不正确");
         }
         
@@ -287,16 +287,16 @@ const getTimeSlots = (html) => {
 const saveSchedule = async (courses, courseConfig, timeSlots) => {
     try {
         await Promise.allSettled([
-            window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(courseConfig)),
-            window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses)),
-            window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots))
+            window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(courseConfig)),
+            window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses)),
+            window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots))
         ]);
         
-        AndroidBridge.showToast("课程表导入成功！");
+        window.shiguangBridge.showToast("课程表导入成功！");
         return true;
     } catch (error) {
         console.error("保存课程数据时出错:", error);
-        AndroidBridge.showToast("课程表导入失败：" + error.message);
+        window.shiguangBridge.showToast("课程表导入失败：" + error.message);
         return false;
     }
 };
@@ -327,7 +327,7 @@ const fetchMultiWeekTimetable = async (startDate) => {
     let weekCount = 0;
     let timeSlots = null;
     
-    AndroidBridge.showToast("正在获取课程表数据，请稍候...");
+    window.shiguangBridge.showToast("正在获取课程表数据，请稍候...");
     
     while (true) {
         weekCount++;
@@ -359,7 +359,7 @@ const fetchMultiWeekTimetable = async (startDate) => {
             }
         } catch (error) {
             console.error(`获取第${weekCount}周课程表失败:`, error);
-            AndroidBridge.showToast(`第${weekCount}周获取失败，继续下一周`);
+            window.shiguangBridge.showToast(`第${weekCount}周获取失败，继续下一周`);
             requestDate = addDays(requestDate, 7);
             continue;
         }
@@ -375,14 +375,14 @@ const fetchMultiWeekTimetable = async (startDate) => {
 // 主函数
 (async () => {
     try {
-        AndroidBridge.showToast("正在启动GDIPU课程表导入...");
+        window.shiguangBridge.showToast("正在启动GDIPU课程表导入...");
         
         const startDate = await promptForStartDate();
         
         const { courses, totalWeeks, timeSlots } = await fetchMultiWeekTimetable(startDate);
         
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程信息");
+            window.shiguangBridge.showToast("未找到任何课程信息");
             throw new Error("未找到课程信息");
         }
         
@@ -393,13 +393,13 @@ const fetchMultiWeekTimetable = async (startDate) => {
         const success = await saveSchedule(courses, courseConfig, timeSlots);
         
         if (success) {
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.notifyTaskCompletion();
         } else {
             throw new Error("保存课程数据失败");
         }
         
     } catch (error) {
         console.error("导入课程表时出错:", error);
-        AndroidBridge.showToast("导入课程表失败：" + error.message);
+        window.shiguangBridge.showToast("导入课程表失败：" + error.message);
     }
 })();

--- a/resources/GDOU/gdou.js
+++ b/resources/GDOU/gdou.js
@@ -170,7 +170,7 @@ function getDefaultAcademicYear(date = new Date()) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "广东海洋大学教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录广东海洋大学教务系统（jw.gdou.edu.cn）。\n本脚本将通过接口直接获取课表，无需停留在特定页面。",
         "好的，开始导入"
@@ -180,7 +180,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = getDefaultAcademicYear();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入 2025）:",
         currentYear,
@@ -191,7 +191,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -228,7 +228,7 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         });
 
         if (!response.ok) {
-            AndroidBridge.showToast(`课表请求失败：HTTP ${response.status}`);
+            window.shiguangBridge.showToast(`课表请求失败：HTTP ${response.status}`);
             console.error(`JS: 接口返回非 200 状态码：${response.status}`);
             return null;
         }
@@ -237,13 +237,13 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         const jsonData = JSON.parse(jsonText);
 
         if (!jsonData || !Array.isArray(jsonData.kbList) || jsonData.kbList.length === 0) {
-            AndroidBridge.showToast("未查询到课表数据，请检查学年/学期是否选择正确，或确认已登录教务系统。");
+            window.shiguangBridge.showToast("未查询到课表数据，请检查学年/学期是否选择正确，或确认已登录教务系统。");
             return null;
         }
 
         const parsedCourses = parseJsonData(jsonData);
         if (parsedCourses.length === 0) {
-            AndroidBridge.showToast("课表数据为空或解析失败，请确认所选学年学期。");
+            window.shiguangBridge.showToast("课表数据为空或解析失败，请确认所选学年学期。");
             return null;
         }
 
@@ -258,20 +258,20 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         };
     } catch (e) {
         console.error("JS: 获取课表失败:", e);
-        AndroidBridge.showToast("获取课表失败，请确认已登录教务系统且网络可访问 jw.gdou.edu.cn。");
+        window.shiguangBridge.showToast("获取课表失败，请确认已登录教务系统且网络可访问 jw.gdou.edu.cn。");
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -294,17 +294,17 @@ const TimeSlots = [
 async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -312,14 +312,14 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -327,7 +327,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -347,19 +347,19 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
         return;
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 脚本执行入口

--- a/resources/GDOU/gdouyj.js
+++ b/resources/GDOU/gdouyj.js
@@ -201,7 +201,7 @@ function getDefaultAcademicYear(date = new Date()) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "广东海洋大学阳江校区教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录广东海洋大学教务系统（jw.gdou.edu.cn）。\n本脚本将通过接口直接获取阳江校区课表，无需停留在特定页面。",
         "好的，开始导入"
@@ -211,7 +211,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = getDefaultAcademicYear();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入 2025）:",
         currentYear,
@@ -222,7 +222,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -259,7 +259,7 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         });
 
         if (!response.ok) {
-            AndroidBridge.showToast(`课表请求失败：HTTP ${response.status}`);
+            window.shiguangBridge.showToast(`课表请求失败：HTTP ${response.status}`);
             console.error(`JS: 接口返回非 200 状态码：${response.status}`);
             return null;
         }
@@ -268,13 +268,13 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         const jsonData = JSON.parse(jsonText);
 
         if (!jsonData || !Array.isArray(jsonData.kbList) || jsonData.kbList.length === 0) {
-            AndroidBridge.showToast("未查询到课表数据，请检查学年/学期是否选择正确，或确认已登录教务系统。");
+            window.shiguangBridge.showToast("未查询到课表数据，请检查学年/学期是否选择正确，或确认已登录教务系统。");
             return null;
         }
 
         const parsedCourses = parseJsonData(jsonData);
         if (parsedCourses.length === 0) {
-            AndroidBridge.showToast("课表数据为空或解析失败，请确认所选学年学期。");
+            window.shiguangBridge.showToast("课表数据为空或解析失败，请确认所选学年学期。");
             return null;
         }
 
@@ -289,20 +289,20 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         };
     } catch (e) {
         console.error("JS: 获取课表失败:", e);
-        AndroidBridge.showToast("获取课表失败，请确认已登录教务系统且网络可访问 jw.gdou.edu.cn。");
+        window.shiguangBridge.showToast("获取课表失败，请确认已登录教务系统且网络可访问 jw.gdou.edu.cn。");
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -325,17 +325,17 @@ const TimeSlots = [
 async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -343,14 +343,14 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -358,7 +358,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -378,19 +378,19 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
         return;
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 脚本执行入口

--- a/resources/GDPU/gdpu_01.js
+++ b/resources/GDPU/gdpu_01.js
@@ -110,7 +110,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中登录广东药科大学教务系统并进入课表页面",
         "好的，开始导入"
@@ -119,7 +119,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -129,7 +129,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -148,7 +148,7 @@ async function selectCampus() {
     const campusKeys = ["campus_1", "campus_2"];
     const campusDisplayNames = ["广州、云浮校区", "中山校区"];
     
-    const campusIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const campusIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择校区",
         JSON.stringify(campusDisplayNames),
         0
@@ -162,7 +162,7 @@ async function selectCampus() {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
     const semesterCode = getSemesterCode(semesterIndex);
     const xnmXqmBody = `xnm=${academicYear}&xqm=${semesterCode}&kzlx=ck&xsdm=&kclbdm=`; 
     const url = "https://webvpn.gdpu.edu.cn/http/77726476706e69737468656265737421fae05285347e6f546e1dc7a99c406d36fe/kbcx/xskbcx_cxXsgrkb.html?vpn-12-o1-jwsys.gdpu.edu.cn&gnmkdm=N2151";
@@ -187,14 +187,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         try {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
-            AndroidBridge.showToast("数据解析失败，请检查是否登录过期。");
+            window.shiguangBridge.showToast("数据解析失败，请检查是否登录过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到课程数据，请检查学年学期。");
+            window.shiguangBridge.showToast("未找到课程数据，请检查学年学期。");
             return null;
         }
         
@@ -208,19 +208,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求失败: ${error.message}`);
         console.error(error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error(error);
         return false;
     }
@@ -270,7 +270,7 @@ async function importPresetTimeSlots(campusKey) {
     const timeSlots = CampusTimeSlots[campusKey];
     if (timeSlots && timeSlots.length > 0) {
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         } catch (error) {
             console.error(error);
         }
@@ -279,7 +279,7 @@ async function importPresetTimeSlots(campusKey) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先在浏览器登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先在浏览器登录教务系统！");
         return;
     }
     const alertConfirmed = await promptUserToStart();
@@ -302,14 +302,14 @@ async function runImportFlow() {
     if (!saveResult) return;
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     } catch (error) {
         console.error(error);
     }
 
     await importPresetTimeSlots(campusKey);
-    AndroidBridge.showToast(`导入成功，共导入 ${courses.length} 门课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/GDUST/gdust.js
+++ b/resources/GDUST/gdust.js
@@ -126,7 +126,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -136,7 +136,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -147,7 +147,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -209,19 +209,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             console.error(`Entry failed: ${url}`);
         }
     }
-    AndroidBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -245,17 +245,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -265,14 +265,14 @@ async function runImportFlow() {
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -281,7 +281,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -301,10 +301,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -312,9 +312,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/GLMU/glmu.js
+++ b/resources/GLMU/glmu.js
@@ -123,7 +123,7 @@ async function fetchCourseData(xnxqdm) {
 
 // ---------- 用户交互 ----------
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "重要提醒",
         "请确保您已登录桂医教务系统，且当前页面为教务系统内任意页面。\n\n点击确定继续。",
         "确定"
@@ -131,7 +131,7 @@ async function promptUserToStart() {
 }
 
 async function getAcademicYear() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "学年设置",
         "请输入本学年开始的年份\n（例如 2024，代表 2024-2025 学年）",
         "2024",
@@ -141,7 +141,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesterOptions = ["上学期", "下学期", "短学期"];
-    const index = await window.AndroidBridgePromise.showSingleSelection(
+    const index = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesterOptions),
         0
@@ -156,38 +156,38 @@ async function run() {
         // 1. 公告
         const confirmed = await promptUserToStart();
         if (!confirmed) {
-            AndroidBridge.showToast("用户取消了导入流程。");
+            window.shiguangBridge.showToast("用户取消了导入流程。");
             return;
         }
 
         // 2. 获取学年
         const yearInput = await getAcademicYear();
         if (yearInput === null) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
         const yearNum = parseInt(yearInput);
         if (isNaN(yearNum) || yearNum < 2000 || yearNum > 2100) {
-            await window.AndroidBridgePromise.showAlert("错误", "学年输入无效，请输入2000-2100之间的数字。", "确定");
+            await window.shiguangBridgePromise.showAlert("错误", "学年输入无效，请输入2000-2100之间的数字。", "确定");
             return;
         }
 
         // 3. 获取学期
         const semesterIndex = await selectSemester();
         if (semesterIndex === null) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
         const termCode = semesterIndex === 0 ? "01" : (semesterIndex === 1 ? "02" : "03");
         const xnxqdm = `${yearNum}${termCode}`;
 
         // 4. 请求课表
-        AndroidBridge.showToast("正在获取课表，请稍候...");
+        window.shiguangBridge.showToast("正在获取课表，请稍候...");
         let rawData;
         try {
             rawData = await fetchCourseData(xnxqdm);
         } catch (fetchErr) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "网络请求失败",
                 `请求教务系统失败：${fetchErr.message}\n\n请检查网络连接和登录状态。`,
                 "确定"
@@ -196,7 +196,7 @@ async function run() {
         }
 
         if (!rawData.length) {
-            await window.AndroidBridgePromise.showAlert("提示", "未获取到任何课程数据。请确认已登录教务系统并选择正确的学年学期。", "确定");
+            await window.shiguangBridgePromise.showAlert("提示", "未获取到任何课程数据。请确认已登录教务系统并选择正确的学年学期。", "确定");
             return;
         }
 
@@ -206,37 +206,37 @@ async function run() {
 
         // 6. 保存课程
         try {
-            await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(targetCourses));
-            AndroidBridge.showToast(`课程数据已导入（共 ${targetCourses.length} 条）`);
+            await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(targetCourses));
+            window.shiguangBridge.showToast(`课程数据已导入（共 ${targetCourses.length} 条）`);
         } catch (saveErr) {
-            await window.AndroidBridgePromise.showAlert("保存课程失败", saveErr.message, "确定");
+            await window.shiguangBridgePromise.showAlert("保存课程失败", saveErr.message, "确定");
             return;
         }
 
         // 7. 保存时间段
         const timeSlots = getTimeSlots();
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("时间段数据已导入");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("时间段数据已导入");
         } catch (slotErr) {
             // 时间段保存失败不终止流程，只提示
-            AndroidBridge.showToast(`时间段保存失败：${slotErr.message}`);
+            window.shiguangBridge.showToast(`时间段保存失败：${slotErr.message}`);
         }
 
         // 8. 完成通知
-        AndroidBridge.showToast("导入完成！");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("导入完成！");
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (err) {
         // 捕获所有未预料的错误
         console.error("run error:", err);
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "导入失败",
             `未知错误：${err.message || err}\n\n请联系开发者。`,
             "确定"
         );
         // 仍然通知完成，但可能不会生成有效文件
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     }
 }
 

--- a/resources/GLOBAL_TOOLS/starlink.js
+++ b/resources/GLOBAL_TOOLS/starlink.js
@@ -79,7 +79,7 @@ function processAndMergeCourses(courses) {
 // 主程序
 async function runStarlinkImport() {
     try {
-        const userInput = await window.AndroidBridgePromise.showPrompt(
+        const userInput = await window.shiguangBridgePromise.showPrompt(
             "导入星链课表",
             "请粘贴分享文案（包含分享码）",
             "",
@@ -91,7 +91,7 @@ async function runStarlinkImport() {
         const shareCode = extractShareCode(userInput);
         const apiUrl = `https://api.starlinkkb.cn/share/curriculum/${shareCode}`;
         
-        AndroidBridge.showToast("正在同步云端数据...");
+        window.shiguangBridge.showToast("正在同步云端数据...");
 
         const response = await fetch(apiUrl);
         if (!response.ok) throw new Error("分享码已失效或网络异常");
@@ -119,15 +119,15 @@ async function runStarlinkImport() {
             semesterTotalWeeks: data.totalWeeks || 20
         };
 
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        const success = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        const success = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
 
         if (success) {
-            AndroidBridge.showToast("导入成功！");
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.showToast("导入成功！");
+            window.shiguangBridge.notifyTaskCompletion();
         }
     } catch (e) {
-        await window.AndroidBridgePromise.showAlert("导入失败", e.message, "确定");
+        await window.shiguangBridgePromise.showAlert("导入失败", e.message, "确定");
     }
 }
 

--- a/resources/GLOBAL_TOOLS/wake_up.js
+++ b/resources/GLOBAL_TOOLS/wake_up.js
@@ -510,7 +510,7 @@ async function wakeupDecodeShareCode(code) {
 
 /** 将 WakeUP 分享数据（多个换行分隔的 JSON 块）解析成各部分。 */
 function parseRawScheduleData(rawData) {
-    AndroidBridge.showToast("正在解析原始数据...");
+    window.shiguangBridge.showToast("正在解析原始数据...");
     const parts = rawData.trim().split("\n");
     if (parts.length < 5) throw new Error("数据格式不完整，预期至少包含 5 个部分。");
     return {
@@ -542,7 +542,7 @@ function convertToSemesterStartDate(rawDate) {
 /** 通过 WakeUP v6.1.70 官方渠道获取、解密、解析并转换课程表。 */
 async function fetchAndParseData(shareKey) {
     try {
-        AndroidBridge.showToast("正在通过 WakeUP 官方渠道请求课表数据...");
+        window.shiguangBridge.showToast("正在通过 WakeUP 官方渠道请求课表数据...");
         const parsedData = parseRawScheduleData(await wakeupDecodeShareCode(shareKey.trim()));
         let rawNodes = parsedData.uiConfig.nodes;
         if (!Array.isArray(rawNodes)) {
@@ -566,11 +566,11 @@ async function fetchAndParseData(shareKey) {
             defaultBreakDuration: parsedData.baseConfig.theBreakLen
         };
         const courses = convertToCourseJsonModel(parsedData);
-        AndroidBridge.showToast(`数据解析成功，共 ${courses.length} 门课程`);
+        window.shiguangBridge.showToast(`数据解析成功，共 ${courses.length} 门课程`);
         return { timeSlots, courseConfig, courses };
     } catch (error) {
         console.error("WakeUP 数据获取或解析失败:", error);
-        AndroidBridge.showToast(`数据获取或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`数据获取或解析失败: ${error.message}`);
         return null;
     }
 }
@@ -632,17 +632,17 @@ function convertToCourseJsonModel(parsedData) {
 
 async function saveTimeSlots(timeSlots) {
     if (timeSlots.length === 0) {
-        AndroidBridge.showToast("没有可导入的时间段数据。");
+        window.shiguangBridge.showToast("没有可导入的时间段数据。");
         return true;
     }
     try {
         console.log("正在导入时间段...");
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-        AndroidBridge.showToast(`成功导入 ${timeSlots.length} 个时间段！`);
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        window.shiguangBridge.showToast(`成功导入 ${timeSlots.length} 个时间段！`);
         return true;
     } catch (error) {
         console.error("导入时间段失败:", error);
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false;
     }
 }
@@ -650,46 +650,46 @@ async function saveTimeSlots(timeSlots) {
 async function saveConfig(configData) {
     try {
         console.log("正在导入课表配置...");
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
-        AndroidBridge.showToast("课表配置（学期/时长）更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        window.shiguangBridge.showToast("课表配置（学期/时长）更新成功！");
         return true;
     } catch (error) {
         console.error("导入配置失败:", error);
-        AndroidBridge.showToast("导入配置失败: " + error.message);
+        window.shiguangBridge.showToast("导入配置失败: " + error.message);
         return false;
     }
 }
 
 async function saveCourses(courses) {
     if (courses.length === 0) {
-        AndroidBridge.showToast("没有课程数据需要导入。");
+        window.shiguangBridge.showToast("没有课程数据需要导入。");
         return true;
     }
     try {
         console.log("正在导入课程数据...");
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
         return true;
     } catch (error) {
         console.error("导入课程失败:", error);
-        AndroidBridge.showToast("导入课程失败: " + error.message);
+        window.shiguangBridge.showToast("导入课程失败: " + error.message);
         return false;
     }
 }
 
 async function runImportFlow() {
     console.log("Wakeup 课表分享导入流程启动...");
-    AndroidBridge.showToast("课表导入流程即将开始...");
+    window.shiguangBridge.showToast("课表导入流程即将开始...");
 
     // 获取用户输入
-    const userInput = await window.AndroidBridgePromise.showPrompt(
+    const userInput = await window.shiguangBridgePromise.showPrompt(
         "输入课表分享口令",
         "可直接粘贴分享的整段文本，系统会自动提取 Key",
         "",
         "validateKey"
     );
     if (userInput === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -721,8 +721,8 @@ async function runImportFlow() {
     }
 
     // 流程完全成功，发送结束信号
-    AndroidBridge.showToast("所有任务已成功完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已成功完成！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/GSCMXY/gscmxy.js
+++ b/resources/GSCMXY/gscmxy.js
@@ -114,7 +114,7 @@ function applyCourseChanges(parsedCourses, rawChanges) {
     }
 
     if (successCount > 0) {
-        AndroidBridge.showToast(`已应用 ${successCount} 条调课/停课变更，获得实际课表。`);
+        window.shiguangBridge.showToast(`已应用 ${successCount} 条调课/停课变更，获得实际课表。`);
     }
 
     return parsedCourses.map(c => {
@@ -137,13 +137,13 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "甘肃财贸职业学院课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统，确认当前页面有显示课表。",
         "好的，开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return null;
     }
     return true;
@@ -151,7 +151,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear();
-    const yearSelection = await window.AndroidBridgePromise.showPrompt(
+    const yearSelection = await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2026-2027 应输入2026）:",
         String(currentYear),
@@ -162,7 +162,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["1 (秋季学期/上学期)", "2 (春季学期/下学期)"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -186,13 +186,13 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         const response = await fetch(courseUrl, { "headers": headers, "body": courseBody, "method": "POST", "credentials": "include" });
         rawCourseData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求课表 API 失败，请检查网络和登录状态。");
+        window.shiguangBridge.showToast("请求课表 API 失败，请检查网络和登录状态。");
         return null;
     }
 
     const rawCourses = rawCourseData?.datas?.cxxszhxqkb?.rows || [];
     if (rawCourses.length === 0) {
-        AndroidBridge.showToast("该学期未查询到您的课程数据。");
+        window.shiguangBridge.showToast("该学期未查询到您的课程数据。");
         return null;
     }
     let parsedCourses = rawCourses.map(c => parseSingleCourse(c)).filter(c => c !== null);
@@ -204,7 +204,7 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         const response = await fetch(changeUrl, { "headers": headers, "body": changeBody, "method": "POST", "credentials": "include" });
         rawChangeData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求调课 API 失败，将使用未调整的课表数据。");
+        window.shiguangBridge.showToast("请求调课 API 失败，将使用未调整的课表数据。");
     }
 
     const rawChanges = rawChangeData?.datas?.xsdkkc?.rows || [];
@@ -225,21 +225,21 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
 
 async function saveCourses(parsedCourses) {
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("没有有效的课程数据可供保存。");
+        window.shiguangBridge.showToast("没有有效的课程数据可供保存。");
         return true;
     }
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存课程数据失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存课程数据失败: ${error.message}`);
         return false;
     }
 }
 
 async function importPresetTimeSlots() {
-    AndroidBridge.showToast("正在导入预设节次时间...");
+    window.shiguangBridge.showToast("正在导入预设节次时间...");
 
     const presetTimeSlots = [
         { "number": 1, "startTime": "08:50", "endTime": "09:30" },
@@ -255,41 +255,41 @@ async function importPresetTimeSlots() {
     ];
 
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false;
     }
 }
 
 async function saveConfig(configData) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
-        AndroidBridge.showToast("课表配置更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        window.shiguangBridge.showToast("课表配置更新成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
 
 async function runImportFlow() {
-    AndroidBridge.showToast("甘肃财贸职业学院课程导入流程启动...");
+    window.shiguangBridge.showToast("甘肃财贸职业学院课程导入流程启动...");
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) return;
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const semesterCode = await selectSemester();
     if (semesterCode === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -304,8 +304,8 @@ async function runImportFlow() {
     const saveResult = await saveCourses(courseData.courses);
     if (!saveResult) return;
 
-    AndroidBridge.showToast("所有任务已完成！课表导入成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！课表导入成功。");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/GSMC/gsmc_01.js
+++ b/resources/GSMC/gsmc_01.js
@@ -137,7 +137,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -147,7 +147,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（如2025-2026 应该填2025）:",
         currentYear,
@@ -158,7 +158,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -179,7 +179,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -211,14 +211,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -234,21 +234,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -274,17 +274,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -292,21 +292,21 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -315,7 +315,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -335,10 +335,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -346,9 +346,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/GUC/school.js
+++ b/resources/GUC/school.js
@@ -200,88 +200,88 @@ async function fetchTimetable(selectTableType) {
 // ==================== 主流程 ====================
 
 async function runImportFlow() {
-    AndroidBridge.showToast("正在初始化吉利学院课表导入...");
+    window.shiguangBridge.showToast("正在初始化吉利学院课表导入...");
 
     // 1. 前置提示
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "请确认已在当前页面成功登录教务系统（输入学号、密码及验证码）。\n登录成功后点击“好的，开始导入”。",
         "好的，开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("已取消导入");
+        window.shiguangBridge.showToast("已取消导入");
         return;
     }
 
     // 2. 检测登录状态
-    AndroidBridge.showToast("正在检测登录状态...");
+    window.shiguangBridge.showToast("正在检测登录状态...");
     if (!(await isLoggedIn())) {
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "未检测到登录状态",
             "当前会话未登录，请先在页面中完成登录，之后重新发起导入。",
             "知道了"
         );
-        AndroidBridge.showToast("未登录，导入中止");
+        window.shiguangBridge.showToast("未登录，导入中止");
         return;
     }
 
     // 3. 选择学期
     const semesters = ["本学期", "下学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
     );
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("已取消学期选择");
+        window.shiguangBridge.showToast("已取消学期选择");
         return;
     }
     const selectTableType = semesterIndex === 0 ? "ThisTerm" : "NextTerm";
 
     // 4. 拉取课表页面
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
     const html = await fetchTimetable(selectTableType);
     if (!html) {
-        AndroidBridge.showToast("获取课表失败，请确认登录状态后重试");
+        window.shiguangBridge.showToast("获取课表失败，请确认登录状态后重试");
         return;
     }
 
     // 5. 解析课程
     const courses = parseTimetableToCourses(html);
     if (courses.length === 0) {
-        AndroidBridge.showToast("未解析到课程数据，请确认当前学期是否有课程");
+        window.shiguangBridge.showToast("未解析到课程数据，请确认当前学期是否有课程");
         return;
     }
     console.log("解析到课程记录数:", courses.length, courses);
 
     // 6. 保存课程
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast(`成功保存 ${courses.length} 条课程记录`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast(`成功保存 ${courses.length} 条课程记录`);
     } catch (e) {
-        AndroidBridge.showToast("课程保存失败: " + e.message);
+        window.shiguangBridge.showToast("课程保存失败: " + e.message);
         return;
     }
 
     // 7. 保存作息时间
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-        AndroidBridge.showToast("作息时间保存成功");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+        window.shiguangBridge.showToast("作息时间保存成功");
     } catch (e) {
-        AndroidBridge.showToast("作息时间保存失败: " + e.message);
+        window.shiguangBridge.showToast("作息时间保存失败: " + e.message);
     }
 
     // 8. 保存课表配置（按课程数据中的最大周数设置学期总周数）
     try {
         const maxWeek = courses.reduce((max, c) => Math.max(max, Math.max(...c.weeks)), 0);
         const config = { semesterStartDate: null, semesterTotalWeeks: Math.max(maxWeek, 1) };
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     } catch (e) {
-        AndroidBridge.showToast("课表配置保存失败: " + e.message);
+        window.shiguangBridge.showToast("课表配置保存失败: " + e.message);
     }
 
-    AndroidBridge.showToast(`课表导入完成，共 ${courses.length} 条记录`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课表导入完成，共 ${courses.length} 条记录`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/GUIT/guit_01.js
+++ b/resources/GUIT/guit_01.js
@@ -68,8 +68,8 @@ const DAY_FIELD_MAP = {
 };
 
 function showToast(message) {
-    if (typeof AndroidBridge !== "undefined" && AndroidBridge.showToast) {
-        AndroidBridge.showToast(message);
+    if (typeof window.shiguangBridge !== "undefined" && window.shiguangBridge.showToast) {
+        window.shiguangBridge.showToast(message);
     } else {
         console.log(message);
     }
@@ -367,11 +367,11 @@ async function selectTerm(terms) {
     });
     const defaultIndex = getDefaultTermIndex(terms);
 
-    if (typeof window.AndroidBridgePromise === "undefined") {
+    if (typeof window.shiguangBridgePromise === "undefined") {
         return terms[defaultIndex];
     }
 
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择要导入的学期",
         JSON.stringify(items),
         defaultIndex
@@ -444,15 +444,15 @@ async function saveConfig(term) {
         firstDayOfWeek: 1
     };
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 async function saveTimeSlots() {
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(PRIMARY_TIME_SLOTS));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(PRIMARY_TIME_SLOTS));
 }
 
 async function saveCourses(courses) {
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 }
 
 async function runImportFlow() {
@@ -474,7 +474,7 @@ async function runImportFlow() {
             throw new Error("未解析到课程，请确认当前账号已在教务系统中可查看课表。");
         }
 
-        if (typeof window.AndroidBridgePromise === "undefined") {
+        if (typeof window.shiguangBridgePromise === "undefined") {
             console.log("Selected term:", selectedTerm);
             console.log("Courses:", courses);
             console.log("Time slots:", PRIMARY_TIME_SLOTS);
@@ -487,8 +487,8 @@ async function runImportFlow() {
         await saveCourses(courses);
 
         showToast(`导入完成，共 ${courses.length} 门课程`);
-        if (typeof AndroidBridge !== "undefined" && AndroidBridge.notifyTaskCompletion) {
-            AndroidBridge.notifyTaskCompletion();
+        if (typeof window.shiguangBridge !== "undefined" && window.shiguangBridge.notifyTaskCompletion) {
+            window.shiguangBridge.notifyTaskCompletion();
         }
     } catch (error) {
         console.error(error);

--- a/resources/GXDLXY/gxdlxy_01.js
+++ b/resources/GXDLXY/gxdlxy_01.js
@@ -159,7 +159,7 @@ function parseTimetableToModel(htmlString) {
 // 交互封装模块
 
 async function showWelcomeAlert() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "导入提示",
         "请确保已在内置浏览器中成功登录广西电力职业技术学院教务系统。",
         "开始导入"
@@ -168,7 +168,7 @@ async function showWelcomeAlert() {
 
 async function getSemesterParamsFromUser() {
     const currentYear = new Date().getFullYear();
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入起始学年（如2025代表2025-2026学年）:",
         String(currentYear),
@@ -176,7 +176,7 @@ async function getSemesterParamsFromUser() {
     );
     if (!year) return null;
 
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(["第一学期", "第二学期"]),
         0
@@ -190,7 +190,7 @@ async function getSemesterParamsFromUser() {
 // 网络与存储封装模块
 
 async function fetchCourseHtml(semesterId) {
-    AndroidBridge.showToast("正在请求课表数据，请稍候...");
+    window.shiguangBridge.showToast("正在请求课表数据，请稍候...");
     const response = await fetch("https://jw.vpn.gxdlxy.com/jsxsd/xskb/xskb_list.do", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -201,7 +201,7 @@ async function fetchCourseHtml(semesterId) {
 }
 
 async function saveCourseDataToApp(courses) {
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         "semesterTotalWeeks": 20,
         "firstDayOfWeek": 1
     }));
@@ -218,10 +218,10 @@ async function saveCourseDataToApp(courses) {
         { "number": 9, "startTime": "19:40", "endTime": "20:20" },
         { "number": 10, "startTime": "20:30", "endTime": "21:10" }
     ];
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 
     // 保存最终课程
-    return await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    return await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 }
 
 // 流程控制模块
@@ -239,18 +239,18 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(html);
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程，请检查学期选择或登录状态。");
+            window.shiguangBridge.showToast("未发现课程，请检查学期选择或登录状态。");
             return;
         }
 
         await saveCourseDataToApp(finalCourses);
 
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error(error);
-        AndroidBridge.showToast("导入异常: " + error.message);
+        window.shiguangBridge.showToast("导入异常: " + error.message);
     }
 }
 

--- a/resources/GZST/gzst.js
+++ b/resources/GZST/gzst.js
@@ -97,7 +97,7 @@ function parseCourseTable(htmlContent) {
 
     const table = doc.getElementById('kbtable');
     if (!table) {
-        AndroidBridge.showToast("错误：未找到课表表格 (id=kbtable)。");
+        window.shiguangBridge.showToast("错误：未找到课表表格 (id=kbtable)。");
         return [];
     }
     
@@ -248,7 +248,7 @@ function mergeCourses(courses) {
 
 // 网络请求函数
 async function fetchCourseHtml() {
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
     const URL = "https://jw.educationgroup.cn/gzstzyxy_jsxsd/xskb/xskb_list.do";
     try {
         const response = await fetch(URL, {
@@ -262,10 +262,10 @@ async function fetchCourseHtml() {
         
         const text = await response.text();
         
-        AndroidBridge.showToast("课表数据获取成功，开始解析...");
+        window.shiguangBridge.showToast("课表数据获取成功，开始解析...");
         return text;
     } catch (error) {
-        AndroidBridge.showToast(`网络请求异常: ${error.message}`);
+        window.shiguangBridge.showToast(`网络请求异常: ${error.message}`);
         return null;
     }
 }
@@ -273,62 +273,62 @@ async function fetchCourseHtml() {
 
 async function importPresetTimeSlots() {
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false; 
     }
 }
 
 async function saveConfig() {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(CourseConfig));
-        AndroidBridge.showToast("课表配置更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(CourseConfig));
+        window.shiguangBridge.showToast("课表配置更新成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
 
 async function saveCourses(parsedCourses, originalCount, mergedCount) {
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("未解析到任何课程数据，跳过保存。");
+        window.shiguangBridge.showToast("未解析到任何课程数据，跳过保存。");
         return true;
     }
     
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         if (originalCount !== undefined && mergedCount !== undefined) {
-             AndroidBridge.showToast(`课程导入成功！原始 ${originalCount} 条，去重合并 ${mergedCount} 条，最终导入 ${parsedCourses.length} 条。`);
+             window.shiguangBridge.showToast(`课程导入成功！原始 ${originalCount} 条，去重合并 ${mergedCount} 条，最终导入 ${parsedCourses.length} 条。`);
         } else {
-             AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 条课程！`);
+             window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 条课程！`);
         }
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存失败: ${error.message}`);
         return false;
     }
 }
 
 async function runImportFlow() {
     
-    const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
         "开始导入",
         "请确保您已登录教务系统，即将获取课表数据并进行课程去重和合并。",
         "确定"
     );
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     // 获取 HTML
     const htmlContent = await fetchCourseHtml();
     if (htmlContent === null) {
-        AndroidBridge.showToast("导入终止。");
+        window.shiguangBridge.showToast("导入终止。");
         return; 
     }
     
@@ -336,7 +336,7 @@ async function runImportFlow() {
     let parsedCourses = parseCourseTable(htmlContent);
     
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("解析失败或未发现有效课程。导入终止。");
+        window.shiguangBridge.showToast("解析失败或未发现有效课程。导入终止。");
         return;
     }
     
@@ -356,8 +356,8 @@ async function runImportFlow() {
     if (!await saveCourses(parsedCourses, originalCourseCount, mergedCount)) return;
 
     // 流程成功
-    AndroidBridge.showToast("所有任务已完成！课表已导入成功！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！课表已导入成功！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/GZTRC/gztrc.js
+++ b/resources/GZTRC/gztrc.js
@@ -187,7 +187,7 @@ async function fetchCourseSchedule(semester, studentId) {
  */
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("开始导入课表...");
+        window.shiguangBridge.showToast("开始导入课表...");
         
         // 1. 解析用户信息
         const userInfo = parseUserFromCookie();
@@ -197,7 +197,7 @@ async function runImportFlow() {
         const studentId = userInfo.userName;
         
         // 2. 获取学期列表
-        AndroidBridge.showToast("正在获取学期列表...");
+        window.shiguangBridge.showToast("正在获取学期列表...");
         const semesters = await fetchSemesterList();
         if (!semesters || semesters.length === 0) {
             throw new Error("未能获取学期列表，请确认已登录教务系统。");
@@ -212,19 +212,19 @@ async function runImportFlow() {
         }
         
         // 4. 让用户选择学期
-        const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
             "选择学期",
             JSON.stringify(semesters),
             defaultIndex
         );
         if (semesterIndex === null) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
         const selectedSemester = semesters[semesterIndex];
         
         // 5. 获取课表数据
-        AndroidBridge.showToast("正在获取课表数据...");
+        window.shiguangBridge.showToast("正在获取课表数据...");
         const courseData = await fetchCourseSchedule(selectedSemester, studentId);
         
         // 6. 解析课程数据
@@ -241,7 +241,7 @@ async function runImportFlow() {
                     defaultClassDuration: 50,
                     defaultBreakDuration: 10
                 };
-                await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+                await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
             } catch (e) {
                 // 忽略配置保存失败
             }
@@ -250,21 +250,21 @@ async function runImportFlow() {
         // 8. 保存预设时间段
         const timeSlots = getTimeSlots();
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         } catch (e) {
-            AndroidBridge.showToast("时间段导入失败，但课程将继续导入。");
+            window.shiguangBridge.showToast("时间段导入失败，但课程将继续导入。");
         }
         
         // 9. 保存课程数据
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (saveResult) {
-            AndroidBridge.showToast("成功导入 " + courses.length + " 条课程记录！");
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.showToast("成功导入 " + courses.length + " 条课程记录！");
+            window.shiguangBridge.notifyTaskCompletion();
         }
         
     } catch (e) {
         console.error("[适配脚本错误] " + e.message);
-        AndroidBridge.showToast("导入失败: " + e.message);
+        window.shiguangBridge.showToast("导入失败: " + e.message);
     }
 }
 

--- a/resources/GZU/gzu.js
+++ b/resources/GZU/gzu.js
@@ -118,7 +118,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已登录教务系统并进入课表查询页面",
         "好的，开始导入"
@@ -127,7 +127,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -137,7 +137,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -188,17 +188,17 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         console.error("获取课表失败: " + e);
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查是否已登录并进入课表页面。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查是否已登录并进入课表页面。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
+    window.shiguangBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         return true;
     } catch (error) {
-        AndroidBridge.showToast("课程保存失败: " + error.message);
+        window.shiguangBridge.showToast("课程保存失败: " + error.message);
         return false;
     }
 }
@@ -220,12 +220,12 @@ const TimeSlots = [
 
 async function importPresetTimeSlots(timeSlots) {
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
+        window.shiguangBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         }
     }
 }
@@ -233,19 +233,19 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -257,16 +257,16 @@ async function runImportFlow() {
     if (!saveResult) return;
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
     } catch (error) {
-        AndroidBridge.showToast("课表配置保存失败: " + error.message);
+        window.shiguangBridge.showToast("课表配置保存失败: " + error.message);
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast("课程导入成功，共导入 " + courses.length + " 门课程！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("课程导入成功，共导入 " + courses.length + " 门课程！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/HAUT/haut_01.js
+++ b/resources/HAUT/haut_01.js
@@ -137,7 +137,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -147,7 +147,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -158,7 +158,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -179,7 +179,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -211,14 +211,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -234,21 +234,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -273,17 +273,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -291,21 +291,21 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -314,7 +314,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -334,10 +334,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -345,9 +345,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/HBGUHX/hbguhx_01.js
+++ b/resources/HBGUHX/hbguhx_01.js
@@ -314,7 +314,7 @@ function calculateCurrentWeek(semesterId) {
  * 显示欢迎提示
  */
 async function showWelcomeAlert() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "导入提示",
         "请确保已在学期理论课表页面,（首页课表是本周课表不可导入,请进入学期理论课表页面）",
         "开始导入"
@@ -326,14 +326,14 @@ async function showWelcomeAlert() {
  */
 async function getSemesterParamsFromUser(semesterOptions) {
     if (!semesterOptions || semesterOptions.length === 0) {
-        AndroidBridge.showToast("未获取到学期列表");
+        window.shiguangBridge.showToast("未获取到学期列表");
         return null;
     }
     
     // 直接显示所有学期选项，让用户一次性选择
     const semesterLabels = semesterOptions.map(opt => opt.text);
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesterLabels),
         0 // 默认选择第一个（最新学期）
@@ -378,7 +378,7 @@ async function saveCourseDataToApp(courses, timeSlots, semesterId) {
     const currentWeek = calculateCurrentWeek(semesterId);
 
     // 保存学期配置
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         "semesterStartDate": startMonday ? formatDate(startMonday) : null,
         "currentWeek": currentWeek,
         "semesterTotalWeeks": 20,
@@ -387,11 +387,11 @@ async function saveCourseDataToApp(courses, timeSlots, semesterId) {
 
     // 保存作息时间（从网页提取）
     if (timeSlots && timeSlots.length > 0) {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
     }
 
     // 保存课程数据
-    return await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    return await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 }
 
 /**
@@ -444,13 +444,13 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(courseHtml);
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程，请检查学期选择或登录状态。");
+            window.shiguangBridge.showToast("未发现课程，请检查学期选择或登录状态。");
             // 尝试直接从初始 HTML 中解析课程
             const initialCourses = parseTimetableToModel(html);
             if (initialCourses.length > 0) {
                 await saveCourseDataToApp(initialCourses, timeSlots, semesterId);
-                AndroidBridge.showToast(`成功导入 ${initialCourses.length} 门课程`);
-                AndroidBridge.notifyTaskCompletion();
+                window.shiguangBridge.showToast(`成功导入 ${initialCourses.length} 门课程`);
+                window.shiguangBridge.notifyTaskCompletion();
             }
             return;
         }
@@ -458,12 +458,12 @@ async function runImportFlow() {
         // 8. 保存课程数据
         await saveCourseDataToApp(finalCourses, timeSlots, semesterId);
 
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程（当前第 ${calculateCurrentWeek(semesterId)} 周）`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程（当前第 ${calculateCurrentWeek(semesterId)} 周）`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error('导入异常：', error);
-        AndroidBridge.showToast("导入异常：" + error.message);
+        window.shiguangBridge.showToast("导入异常：" + error.message);
     }
 }
 

--- a/resources/HBLGXY/hblgxy_01.js
+++ b/resources/HBLGXY/hblgxy_01.js
@@ -125,7 +125,7 @@ async function saveAppConfig() {
         "semesterTotalWeeks": 20,
         "firstDayOfWeek": 1
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -148,7 +148,7 @@ async function saveAppTimeSlots() {
         { "number": 13, "startTime": "22:40", "endTime": "23:25" },
         { "number": 14, "startTime": "23:25", "endTime": "23:59" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -157,12 +157,12 @@ async function saveAppTimeSlots() {
 async function getSelectedSemesterId() {
     const currentYear = new Date().getFullYear();
     // 绑定验证函数 validateYearInput
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput"
     );
     if (!year) return null;
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", JSON.stringify(["第一学期", "第二学期"]), 0
     );
     if (semesterIndex === null) return null;
@@ -174,23 +174,23 @@ async function getSelectedSemesterId() {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "公告",
             "请确保您已在当前页面成功登录教务系统，否则无法获取数据。是否继续？",
             "确认已登录"
         );
         if (!confirmed) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
         const semesterId = await getSelectedSemesterId();
         if (!semesterId) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         
         const response = await fetch("https://a.hblgxy.edu.cn:5111/jsxsd/xskb/xskb_list.do", {
             method: "POST",
@@ -203,21 +203,21 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
+            window.shiguangBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
             return;
         }
 
         // 保存数据
-        AndroidBridge.showToast("正在保存配置...");
+        window.shiguangBridge.showToast("正在保存配置...");
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/HBMU/hbmu.js
+++ b/resources/HBMU/hbmu.js
@@ -122,7 +122,7 @@ async function fetchCourseData(xnxqdm) {
 
 // ---------- 用户交互 ----------
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "重要提醒",
         "请确保您已登录湖医药教务系统，且当前页面为教务系统内任意页面。\n\n点击确定继续。",
         "确定"
@@ -130,7 +130,7 @@ async function promptUserToStart() {
 }
 
 async function getAcademicYear() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "学年设置",
         "请输入本学年开始的年份\n（例如 2024，代表 2024-2025 学年）",
         "2024",
@@ -140,7 +140,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesterOptions = ["上学期", "下学期", "短学期"];
-    const index = await window.AndroidBridgePromise.showSingleSelection(
+    const index = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesterOptions),
         0
@@ -155,38 +155,38 @@ async function run() {
         // 1. 公告
         const confirmed = await promptUserToStart();
         if (!confirmed) {
-            AndroidBridge.showToast("用户取消了导入流程。");
+            window.shiguangBridge.showToast("用户取消了导入流程。");
             return;
         }
 
         // 2. 获取学年
         const yearInput = await getAcademicYear();
         if (yearInput === null) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
         const yearNum = parseInt(yearInput);
         if (isNaN(yearNum) || yearNum < 2000 || yearNum > 2100) {
-            await window.AndroidBridgePromise.showAlert("错误", "学年输入无效，请输入2000-2100之间的数字。", "确定");
+            await window.shiguangBridgePromise.showAlert("错误", "学年输入无效，请输入2000-2100之间的数字。", "确定");
             return;
         }
 
         // 3. 获取学期
         const semesterIndex = await selectSemester();
         if (semesterIndex === null) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
         const termCode = semesterIndex === 0 ? "01" : (semesterIndex === 1 ? "02" : "03");
         const xnxqdm = `${yearNum}${termCode}`;
 
         // 4. 请求课表
-        AndroidBridge.showToast("正在获取课表，请稍候...");
+        window.shiguangBridge.showToast("正在获取课表，请稍候...");
         let rawData;
         try {
             rawData = await fetchCourseData(xnxqdm);
         } catch (fetchErr) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "网络请求失败",
                 `请求教务系统失败：${fetchErr.message}\n\n请检查网络连接和登录状态。`,
                 "确定"
@@ -195,7 +195,7 @@ async function run() {
         }
 
         if (!rawData.length) {
-            await window.AndroidBridgePromise.showAlert("提示", "未获取到任何课程数据。请确认已登录教务系统并选择正确的学年学期。", "确定");
+            await window.shiguangBridgePromise.showAlert("提示", "未获取到任何课程数据。请确认已登录教务系统并选择正确的学年学期。", "确定");
             return;
         }
 
@@ -205,37 +205,37 @@ async function run() {
 
         // 6. 保存课程
         try {
-            await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(targetCourses));
-            AndroidBridge.showToast(`课程数据已导入（共 ${targetCourses.length} 条）`);
+            await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(targetCourses));
+            window.shiguangBridge.showToast(`课程数据已导入（共 ${targetCourses.length} 条）`);
         } catch (saveErr) {
-            await window.AndroidBridgePromise.showAlert("保存课程失败", saveErr.message, "确定");
+            await window.shiguangBridgePromise.showAlert("保存课程失败", saveErr.message, "确定");
             return;
         }
 
         // 7. 保存时间段
         const timeSlots = getTimeSlots();
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("时间段数据已导入");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("时间段数据已导入");
         } catch (slotErr) {
             // 时间段保存失败不终止流程，只提示
-            AndroidBridge.showToast(`时间段保存失败：${slotErr.message}`);
+            window.shiguangBridge.showToast(`时间段保存失败：${slotErr.message}`);
         }
 
         // 8. 完成通知
-        AndroidBridge.showToast("导入完成！");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("导入完成！");
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (err) {
         // 捕获所有未预料的错误
         console.error("run error:", err);
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "导入失败",
             `未知错误：${err.message || err}\n\n请联系开发者。`,
             "确定"
         );
         // 仍然通知完成，但可能不会生成有效文件
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     }
 }
 

--- a/resources/HFNU/hfnu.js
+++ b/resources/HFNU/hfnu.js
@@ -207,7 +207,7 @@ async function getSelectedSemester(tagId) {
     for (let key in data.semesters) {
         data.semesters[key].forEach(s => list.push({ id: s.id, name: `${s.schoolYear} ${s.name}学期` }));
     }
-    const idx = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(list.map(s => s.name)), -1);
+    const idx = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(list.map(s => s.name)), -1);
     return idx !== null ? list[idx] : null;
 }
 
@@ -252,7 +252,7 @@ async function applyTimeSlots() {
 
     const configs = [timeSlot1, timeSlot2];
     const campusNames = ["锦绣校区", "滨湖校区"];
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择校区", 
         JSON.stringify(campusNames), 
         -1
@@ -260,36 +260,36 @@ async function applyTimeSlots() {
     if (selectedIndex === null) return false;
 
     const target = configs[selectedIndex];
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(target));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(target));
     return true;
 }
 
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("开始探测教务参数...");
+        window.shiguangBridge.showToast("开始探测教务参数...");
         const params = await detectParameters();
         if (!params) throw new Error("未能识别教务参数，请确认已登录");
 
         const semester = await getSelectedSemester(params.tagId);
         if (!semester) return; 
 
-        AndroidBridge.showToast("正在同步课表...");
+        window.shiguangBridge.showToast("正在同步课表...");
         const courses = await fetchAndParseCourses(semester.id, params.ids);
         
         if (!courses || courses.length === 0) throw new Error("未解析到课程数据");
 
         const success = await applyTimeSlots();
         if (!success) return;
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         
         if (saveResult) {
-            AndroidBridge.showToast(`成功导入 ${courses.length} 个课程条目`);
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 个课程条目`);
+            window.shiguangBridge.notifyTaskCompletion();
         }
     } catch (e) {
         console.error(`[异常] ${e.message}`);
-        AndroidBridge.showToast(e.message);
+        window.shiguangBridge.showToast(e.message);
     }
 }
 

--- a/resources/HHTC/hhtc.js
+++ b/resources/HHTC/hhtc.js
@@ -211,7 +211,7 @@ async function saveAppConfig() {
     const config = {
         "firstDayOfWeek": 1
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -230,7 +230,7 @@ async function saveAppTimeSlots() {
         { "number": 9, "startTime": "19:30", "endTime": "20:15" },
         { "number": 10, "startTime": "20:25", "endTime": "21:10" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -238,12 +238,12 @@ async function saveAppTimeSlots() {
  */
 async function getSelectedSemesterId() {
     const currentYear = new Date().getFullYear();
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年", "请输入起始学年（如 2025-2026 应输入 2025）:", String(currentYear), "validateYearInput"
     );
     if (!year) return null;
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", JSON.stringify(["第一学期", "第二学期"]), -1
     );
     if (semesterIndex === null) return null;
@@ -255,7 +255,7 @@ async function getSelectedSemesterId() {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "导入提示",
             "脚本将获取当前教务系统的课表数据。请确保您已登录。是否继续？",
             "确认并开始"
@@ -264,11 +264,11 @@ async function runImportFlow() {
 
         const semesterId = await getSelectedSemesterId();
         if (!semesterId) {
-            AndroidBridge.showToast("用户取消了学期选择");
+            window.shiguangBridge.showToast("用户取消了学期选择");
             return;
         }
 
-        AndroidBridge.showToast("正在请求教务数据...");
+        window.shiguangBridge.showToast("正在请求教务数据...");
         const response = await fetch("https://jwmis.hhtc.edu.cn/jsxsd/xskb/xskb_list.do", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -284,20 +284,20 @@ async function runImportFlow() {
         finalCourses = mergeContinuousLessons(finalCourses);
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程数据，请检查该学期是否有课或登录是否过期");
+            window.shiguangBridge.showToast("未发现课程数据，请检查该学期是否有课或登录是否过期");
             return;
         }
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程！`);
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程！`);
 
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error(error);
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/HIIT/hiit_01.js
+++ b/resources/HIIT/hiit_01.js
@@ -1,7 +1,7 @@
 (function () {
     function showToast(message) {
-        if (typeof AndroidBridge !== "undefined" && AndroidBridge.showToast) {
-            AndroidBridge.showToast(String(message || ""));
+        if (typeof window.shiguangBridge !== "undefined" && window.shiguangBridge.showToast) {
+            window.shiguangBridge.showToast(String(message || ""));
         } else {
             console.log(message);
         }
@@ -444,7 +444,7 @@
 
     async function selectSemester(semesters) {
         const recent = semesters.slice(-8);
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "选择要导入的学期",
             JSON.stringify(recent.map((semester) => semester.name || semester.id)),
             recent.length - 1
@@ -499,15 +499,15 @@
             config.semesterTotalWeeks = calendarInfo.semesterTotalWeeks;
         }
 
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (timeSlots.length) {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         }
 
         showToast(`导入完成，共 ${courses.length} 门课程`);
-        if (typeof AndroidBridge !== "undefined" && AndroidBridge.notifyTaskCompletion) {
-            AndroidBridge.notifyTaskCompletion();
+        if (typeof window.shiguangBridge !== "undefined" && window.shiguangBridge.notifyTaskCompletion) {
+            window.shiguangBridge.notifyTaskCompletion();
         }
     }
 

--- a/resources/HLJU/hlju.js
+++ b/resources/HLJU/hlju.js
@@ -395,11 +395,11 @@ function printCourses(courses) {
 
 async function saveHljuCourses(courses) {
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(
+        await window.shiguangBridgePromise.saveImportedCourses(
             JSON.stringify(courses)
         );
 
-        AndroidBridge.showToast(
+        window.shiguangBridge.showToast(
             `成功导入 ${courses.length} 个课程时段！`
         );
 
@@ -412,7 +412,7 @@ async function saveHljuCourses(courses) {
     } catch (error) {
         console.error("保存课程失败：", error);
 
-        AndroidBridge.showToast(
+        window.shiguangBridge.showToast(
             "课程保存失败：" + error.message
         );
 
@@ -424,7 +424,7 @@ async function saveHljuCourses(courses) {
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast(
+        window.shiguangBridge.showToast(
             "正在获取黑龙江大学课表..."
         );
 
@@ -447,7 +447,7 @@ async function runImportFlow() {
 
         printCourses(courses);
 
-        AndroidBridge.showToast(
+        window.shiguangBridge.showToast(
             `解析成功，共 ${courses.length} 个课程时段`
         );
 
@@ -463,7 +463,7 @@ async function runImportFlow() {
 
 
 
-        AndroidBridge.showToast(
+        window.shiguangBridge.showToast(
             "黑龙江大学课表导入成功！"
         );
 
@@ -472,7 +472,7 @@ async function runImportFlow() {
         );
 
         // 只有全部成功后才发送结束信号
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error(
@@ -480,7 +480,7 @@ async function runImportFlow() {
             error
         );
 
-        AndroidBridge.showToast(
+        window.shiguangBridge.showToast(
             "课表导入失败：" + error.message
         );
     }

--- a/resources/HNIU/hniu_01.js
+++ b/resources/HNIU/hniu_01.js
@@ -174,7 +174,7 @@ async function saveAppConfig() {
         "semesterTotalWeeks": 20,
         "firstDayOfWeek": 1
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -195,7 +195,7 @@ async function saveAppTimeSlots() {
         { "number": 11, "startTime": "20:20", "endTime": "21:00" },
         { "number": 12, "startTime": "21:10", "endTime": "21:50" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -204,12 +204,12 @@ async function saveAppTimeSlots() {
 async function getSelectedSemesterId() {
     const currentYear = new Date().getFullYear();
     // 绑定验证函数 validateYearInput
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput"
     );
     if (!year) return null;
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", JSON.stringify(["第一学期", "第二学期"]), 0
     );
     if (semesterIndex === null) return null;
@@ -221,23 +221,23 @@ async function getSelectedSemesterId() {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "公告",
             "请确保您已在当前页面成功登录教务系统，否则无法获取数据。是否继续？",
             "确认已登录"
         );
         if (!confirmed) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
         const semesterId = await getSelectedSemesterId();
         if (!semesterId) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         
         const response = await fetch("https://jw.hniu.cn/jsxsd/xskb/xskb_list.do", {
             method: "POST",
@@ -250,21 +250,21 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
+            window.shiguangBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
             return;
         }
 
         // 保存数据
-        AndroidBridge.showToast("正在保存配置...");
+        window.shiguangBridge.showToast("正在保存配置...");
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/HNSF/hnsf_01.js
+++ b/resources/HNSF/hnsf_01.js
@@ -99,7 +99,7 @@ function validateYearInput(input) {
 }
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -109,7 +109,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -120,7 +120,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期 (01)", "第二学期 (02)"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -129,7 +129,7 @@ async function selectSemester() {
 }
 
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     // 学年学期代码组合：202501 (第一学期), 202502 (第二学期)
     // semesterIndex 0 对应 01, 1 对应 02
@@ -161,14 +161,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
             return null;
         }
 
@@ -177,7 +177,7 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
@@ -185,14 +185,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
 
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -226,7 +226,7 @@ const SummerTimeSlots = [
 async function selectTimeSlotsType() {
     const timeSlotsOptions = ["非夏季作息", "夏季作息"];
     console.log("JS: 提示用户选择作息时间类型。");
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(timeSlotsOptions),
         0
@@ -238,17 +238,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -256,7 +256,7 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
@@ -264,14 +264,14 @@ async function runImportFlow() {
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -280,7 +280,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -320,9 +320,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(selectedTimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/HNSF/hnsf_02.js
+++ b/resources/HNSF/hnsf_02.js
@@ -76,7 +76,7 @@ async function selectMonth() {
             months.push(`${currentYear + 1}年${month}月`);
         }
         
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择要获取课程的月份",
             JSON.stringify(months),
             0
@@ -110,7 +110,7 @@ async function fetchCoursesData() {
         // 让用户选择月份
         const monthSelection = await selectMonth();
         if (!monthSelection) {
-            AndroidBridge.showToast("用户取消选择月份！");
+            window.shiguangBridge.showToast("用户取消选择月份！");
             return null;
         }
         
@@ -139,7 +139,7 @@ async function fetchCoursesData() {
         return json; // 直接返回课程数据数组
     } catch (err) {
         console.error("获取课程数据失败:", err);
-        AndroidBridge.showToast("获取课程数据失败：" + err.message);
+        window.shiguangBridge.showToast("获取课程数据失败：" + err.message);
         return null;
     }
 }
@@ -202,17 +202,17 @@ async function processCoursesData(coursesData) {
 // ====================== 保存课程 ======================
 async function saveCourses(courses) {
     try {
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (result === true) {
-            AndroidBridge.showToast("课程导入成功！");
+            window.shiguangBridge.showToast("课程导入成功！");
             return true;
         } else {
-            AndroidBridge.showToast("课程导入失败，请查看日志！");
+            window.shiguangBridge.showToast("课程导入失败，请查看日志！");
             return false;
         }
     } catch (err) {
         console.error("保存课程失败:", err);
-        AndroidBridge.showToast("保存课程失败：" + err.message);
+        window.shiguangBridge.showToast("保存课程失败：" + err.message);
         return false;
     }
 }
@@ -234,15 +234,15 @@ async function importPresetTimeSlots() {
     ];
     
     try {
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
-            AndroidBridge.showToast("时间段导入成功！");
+            window.shiguangBridge.showToast("时间段导入成功！");
         } else {
-            AndroidBridge.showToast("时间段导入失败，请查看日志！");
+            window.shiguangBridge.showToast("时间段导入失败，请查看日志！");
         }
     } catch (err) {
         console.error("时间段导入失败:", err);
-        AndroidBridge.showToast("时间段导入失败：" + err.message);
+        window.shiguangBridge.showToast("时间段导入失败：" + err.message);
     }
 }
 
@@ -263,14 +263,14 @@ async function showAnnouncement() {
 使用前请确认网络连接正常！
         `.trim();
         
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "课程导入工具公告",
             announcement
         );
     } catch (err) {
         console.error("显示公告失败:", err);
         // 如果弹窗失败，使用Toast提示
-        AndroidBridge.showToast("课程导入工具启动中...");
+        window.shiguangBridge.showToast("课程导入工具启动中...");
     }
 }
 
@@ -278,14 +278,14 @@ async function showAnnouncement() {
 async function runImportFlow() {
     // 检查用户是否已登录
     if (!isUserLoggedIn()) {
-        AndroidBridge.showToast("检测到未登录状态，请先登录后再使用课程导入功能！");
+        window.shiguangBridge.showToast("检测到未登录状态，请先登录后再使用课程导入功能！");
         return;
     }
     
     // 显示公告
     await showAnnouncement();
     
-    AndroidBridge.showToast("课程导入流程即将开始...");
+    window.shiguangBridge.showToast("课程导入流程即将开始...");
 
     // 1️⃣ 获取课程数据
     const coursesData = await fetchCoursesData();
@@ -296,7 +296,7 @@ async function runImportFlow() {
     // 2️⃣ 处理课程数据
     const courses = await processCoursesData(coursesData);
     if (!courses) {
-        AndroidBridge.showToast("没有找到有效的课程数据！");
+        window.shiguangBridge.showToast("没有找到有效的课程数据！");
         return;
     }
 
@@ -310,9 +310,9 @@ async function runImportFlow() {
     await importPresetTimeSlots();
 
     // ✅ 只有所有步骤都成功完成，才通知任务完成
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS：整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动流程

--- a/resources/HNUST/HNUST_01.js
+++ b/resources/HNUST/HNUST_01.js
@@ -148,11 +148,11 @@ async function selectTimeSlotsType() {
     console.log("JS: 提示用户选择作息时间类型。");
     
     // 如果不在APP内（网页测试环境），默认返回0
-    if (typeof window.AndroidBridgePromise === 'undefined') {
+    if (typeof window.shiguangBridgePromise === 'undefined') {
         return 0; 
     }
     
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(timeSlotsOptions),
         0 // 默认选中第一个
@@ -177,8 +177,8 @@ function getCourseConfig() {
  */
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在获取课表数据，请稍候...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在获取课表数据，请稍候...");
         } else {
             console.log("正在发起请求获取课表...");
         }
@@ -204,20 +204,20 @@ async function runImportFlow() {
             });
         }
 
-        if (semesters.length > 0 && typeof window.AndroidBridgePromise !== 'undefined') {
-            let selectedIdx = await window.AndroidBridgePromise.showSingleSelection(
+        if (semesters.length > 0 && typeof window.shiguangBridgePromise !== 'undefined') {
+            let selectedIdx = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期", 
                 JSON.stringify(semesters), 
                 defaultIndex
             );
 
             if (selectedIdx === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
 
             if (selectedIdx !== defaultIndex) {
-                AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
+                window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
                 let formData = new URLSearchParams();
                 formData.append('xnxq01id', semesterValues[selectedIdx]);
 
@@ -235,8 +235,8 @@ async function runImportFlow() {
         
         if (courses.length === 0) {
             const errMsg = "未能解析到任何课程，请检查是否暂无排课。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else {
                 alert(errMsg);
             }
@@ -247,8 +247,8 @@ async function runImportFlow() {
 
         // ------------------ 选择作息时间阶段 ------------------
         const timeSlotsIndex = await selectTimeSlotsType();
-        if (timeSlotsIndex === null && typeof window.AndroidBridgePromise !== 'undefined') {
-             AndroidBridge.showToast("已取消选择作息时间，终止导入");
+        if (timeSlotsIndex === null && typeof window.shiguangBridgePromise !== 'undefined') {
+             window.shiguangBridge.showToast("已取消选择作息时间，终止导入");
              return;
         }
         
@@ -259,7 +259,7 @@ async function runImportFlow() {
         // -----------------------------------------------------
 
         // 浏览器测试环境，直接输出结果
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【测试成功】课表配置：", config);
             console.log("【测试成功】作息时间：", selectedTimeSlots);
             console.log("【测试成功】课程数据：", courses);
@@ -268,26 +268,26 @@ async function runImportFlow() {
         }
 
         // APP 环境，执行保存配置和作息时间
-        const configSaved = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        const timeSlotsSaved = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(selectedTimeSlots));
+        const configSaved = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        const timeSlotsSaved = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(selectedTimeSlots));
         if (!configSaved || !timeSlotsSaved) {
-            AndroidBridge.showToast("保存课表时间配置失败！");
+            window.shiguangBridge.showToast("保存课表时间配置失败！");
             // 注意：时间配置失败不一定阻断课程导入，这里选择继续导入课程
         }
 
         // APP 环境，执行保存课程
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存课程失败，请重试！");
+            window.shiguangBridge.showToast("保存课程失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("导入发生异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("导入发生异常: " + error.message);
         } else {
             console.error("【导入发生异常】", error);
             alert("导入发生异常: " + error.message);

--- a/resources/HNVCC/HNVCC_01.js
+++ b/resources/HNVCC/HNVCC_01.js
@@ -91,7 +91,7 @@ function parseSections(sectionStr) {
  * @returns {Document | null} 解析后的 Document 对象或 null
  */
 async function fetchTimetable(xnxqid) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
     
     // 完整的 URL 路径
     const url = `http://jwxt.hnvcc.edu.cn/jsxsd/framework/mainV_index_loadkb.htmlx?rq=all&xnxqid=${xnxqid}&xswk=false`;
@@ -104,12 +104,12 @@ async function fetchTimetable(xnxqid) {
         });
 
         if (!response.ok) {
-            AndroidBridge.showToast(`网络响应错误，状态码: ${response.status}。请检查登录状态。`);
+            window.shiguangBridge.showToast(`网络响应错误，状态码: ${response.status}。请检查登录状态。`);
             return null;
         }
 
         const htmlData = await response.text();
-        AndroidBridge.showToast("数据获取成功，开始解析 HTML...");
+        window.shiguangBridge.showToast("数据获取成功，开始解析 HTML...");
         
         const parser = new DOMParser();
         const doc = parser.parseFromString(htmlData, "text/html");
@@ -117,7 +117,7 @@ async function fetchTimetable(xnxqid) {
         return doc;
 
     } catch (error) {
-        AndroidBridge.showToast(`请求过程中发生错误: ${error.message}`);
+        window.shiguangBridge.showToast(`请求过程中发生错误: ${error.message}`);
         return null;
     }
 }
@@ -134,7 +134,7 @@ function parseTimetable(doc) {
     const timetable = doc.getElementById('timetable');
     
     if (!timetable) {
-        AndroidBridge.showToast("HTML 中未找到课表表格 #timetable。");
+        window.shiguangBridge.showToast("HTML 中未找到课表表格 #timetable。");
         return null;
     }
 
@@ -361,32 +361,32 @@ function generateWinterTimeSlots() {
 async function runImportFlow() {
     const currentTitle = document.title || '';
     if (currentTitle.includes('登录') || currentTitle.includes('Login')) {
-        AndroidBridge.showToast("请先登录教务系统");
+        window.shiguangBridge.showToast("请先登录教务系统");
         return;
     }
 
     // 获取用户输入：学年
     let currentYear = new Date().getFullYear();
-    const academicYear = await window.AndroidBridgePromise.showPrompt(
+    const academicYear = await window.shiguangBridgePromise.showPrompt(
         "选择学年", 
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         String(currentYear),
         "validateYearInput"
     );
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     // 获取用户输入：学期
     const semesters = ["1（第一学期）", "2（第二学期）"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", 
         JSON.stringify(semesters),
         -1 
     );
     if (semesterIndex === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     const semesterNumber = semesterIndex + 1;
@@ -394,22 +394,22 @@ async function runImportFlow() {
     // 构造学年学期 ID (xnxqid)
     const nextYear = parseInt(academicYear) + 1;
     const xnxqid = `${academicYear}-${nextYear}-${semesterNumber}`;
-    AndroidBridge.showToast(`准备获取 ${academicYear} 学年第 ${semesterNumber} 学期数据...`);
+    window.shiguangBridge.showToast(`准备获取 ${academicYear} 学年第 ${semesterNumber} 学期数据...`);
     
     // 获取用户输入：作息季节
     const seasons = ["夏季作息", "冬季作息"];
-    const seasonIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const seasonIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息季节", 
         JSON.stringify(seasons),
         -1
     );
     if (seasonIndex === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     const selectedSeason = seasonIndex === 0 ? 'summer' : 'winter';
     const seasonText = seasonIndex === 0 ? '夏季作息' : '冬季作息';
-    AndroidBridge.showToast(`已选择：${seasonText}。`);
+    window.shiguangBridge.showToast(`已选择：${seasonText}。`);
 
     // 异步获取和解析 HTML 数据
     const doc = await fetchTimetable(xnxqid);
@@ -420,7 +420,7 @@ async function runImportFlow() {
     const parsedData = parseTimetable(doc);
     
     if (!parsedData || parsedData.courses.length === 0) {
-        AndroidBridge.showToast("课表解析失败或未解析到课程。请检查登录状态、学期选择或课表数据是否为空。");
+        window.shiguangBridge.showToast("课表解析失败或未解析到课程。请检查登录状态、学期选择或课表数据是否为空。");
         return;
     }
 
@@ -432,20 +432,20 @@ async function runImportFlow() {
     
     // 提交课程数据
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         const mergedCount = originalCourseCount - courses.length;
-        AndroidBridge.showToast(`课程导入成功！原始 ${originalCourseCount} 门，合并 ${mergedCount} 门，最终导入 ${courses.length} 门。`);
+        window.shiguangBridge.showToast(`课程导入成功！原始 ${originalCourseCount} 门，合并 ${mergedCount} 门，最终导入 ${courses.length} 门。`);
     } catch (error) {
-        AndroidBridge.showToast(`课程数据保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程数据保存失败: ${error.message}`);
         return;
     }
 
     // 提交课表配置数据 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
     }
 
     // 提交预设时间段数据
@@ -457,14 +457,14 @@ async function runImportFlow() {
             timeSlots = generateWinterTimeSlots();
         }
 
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-        AndroidBridge.showToast(`预设时间段导入成功！已使用${seasonText}。请在设置中校对具体时间。`);
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        window.shiguangBridge.showToast(`预设时间段导入成功！已使用${seasonText}。请在设置中校对具体时间。`);
     } catch (error) {
-        AndroidBridge.showToast(`导入时间段失败: ${error.message}`);
+        window.shiguangBridge.showToast(`导入时间段失败: ${error.message}`);
     }
 
-    AndroidBridge.showToast("所有任务已完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/HNZY/hnzy.js
+++ b/resources/HNZY/hnzy.js
@@ -72,7 +72,7 @@ async function selectYearAndTerm(schoolYears, schoolTerms) {
             });
         });
 
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择学年和学期",
             JSON.stringify(options),
             0
@@ -99,7 +99,7 @@ async function fetchSchoolYearTerms() {
         };
     } catch (err) {
         console.error("获取学年学期失败:", err);
-        AndroidBridge.showToast("获取学年学期失败：" + err.message);
+        window.shiguangBridge.showToast("获取学年学期失败：" + err.message);
         return null;
     }
 }
@@ -144,17 +144,17 @@ async function fetchCoursesForAllWeeks(year, term) {
 // ====================== 保存课程 ======================
 async function saveCourses(courses) {
     try {
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (result === true) {
-            AndroidBridge.showToast("课程导入成功！");
+            window.shiguangBridge.showToast("课程导入成功！");
             return true;
         } else {
-            AndroidBridge.showToast("课程导入失败，请查看日志！");
+            window.shiguangBridge.showToast("课程导入失败，请查看日志！");
             return false;
         }
     } catch (err) {
         console.error("保存课程失败:", err);
-        AndroidBridge.showToast("保存课程失败：" + err.message);
+        window.shiguangBridge.showToast("保存课程失败：" + err.message);
         return false;
     }
 }
@@ -178,15 +178,15 @@ async function importPresetTimeSlots() {
     ];
     
     try {
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
-            AndroidBridge.showToast("时间段导入成功！");
+            window.shiguangBridge.showToast("时间段导入成功！");
         } else {
-            AndroidBridge.showToast("时间段导入失败，请查看日志！");
+            window.shiguangBridge.showToast("时间段导入失败，请查看日志！");
         }
     } catch (err) {
         console.error("时间段导入失败:", err);
-        AndroidBridge.showToast("时间段导入失败：" + err.message);
+        window.shiguangBridge.showToast("时间段导入失败：" + err.message);
     }
 }
 
@@ -195,11 +195,11 @@ async function importPresetTimeSlots() {
 async function runImportFlow() {
     // 检查用户是否已登录
     if (!isUserLoggedIn()) {
-        AndroidBridge.showToast("检测到未登录状态，请先登录后再使用课程导入功能！");
+        window.shiguangBridge.showToast("检测到未登录状态，请先登录后再使用课程导入功能！");
         return;
     }
     
-    AndroidBridge.showToast("课程导入流程即将开始...");
+    window.shiguangBridge.showToast("课程导入流程即将开始...");
 
     // 1️⃣ 获取学年学期
     const yearTermData = await fetchSchoolYearTerms();
@@ -210,7 +210,7 @@ async function runImportFlow() {
     // 2️⃣ 用户选择
     const selection = await selectYearAndTerm(yearTermData.schoolYears, yearTermData.schoolTerms);
     if (!selection) {
-        AndroidBridge.showToast("用户取消选择！");
+        window.shiguangBridge.showToast("用户取消选择！");
         return;
     }
 
@@ -230,9 +230,9 @@ async function runImportFlow() {
     await importPresetTimeSlots();
 
     // ✅ 只有所有步骤都成功完成，才通知任务完成
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS：整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动流程

--- a/resources/HQU/hquadap.js
+++ b/resources/HQU/hquadap.js
@@ -14,7 +14,7 @@ function validateTermInput(input) {
 }
 
 async function runImportFlow() {
-    AndroidBridge.showToast("正在启动华大教务同步程序...");
+    window.shiguangBridge.showToast("正在启动华大教务同步程序...");
 
     try {
         // --- 1. 获取学期代码 ---
@@ -101,7 +101,7 @@ async function runImportFlow() {
 });
 
         // --- 5. 提交数据 ---
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
             semesterStartDate: startDate,
             semesterTotalWeeks: totalWeeks
         }));
@@ -115,15 +115,15 @@ async function runImportFlow() {
             { number: 11, startTime: "19:10", endTime: "19:55" }, { number: 12, startTime: "20:05", endTime: "20:50" },
             { number: 13, startTime: "20:55", endTime: "21:40" }
         ];
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
 
-        AndroidBridge.showToast(`${currentXNXQ} 导入成功！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`${currentXNXQ} 导入成功！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (e) {
-        await window.AndroidBridgePromise.showAlert("导入失败", "错误: " + e.message, "重试");
+        await window.shiguangBridgePromise.showAlert("导入失败", "错误: " + e.message, "重试");
     }
 }
 

--- a/resources/HUAT/HUAT.js
+++ b/resources/HUAT/HUAT.js
@@ -495,7 +495,7 @@ function getSeasonTimeSlots(season) {
 // ==================== 弹窗和导入函数 ====================
 async function demoAlert() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "📚 湖北汽车工业学院课表导入",
             "将提取当前页面的课表数据并导入到App\n\n" +
             "📌 请确认已在课表页面\n" +
@@ -512,7 +512,7 @@ async function demoAlert() {
 async function demoPrompt() {
     try {
         const semesterInfo = extractSemesterInfo();
-        const semesterStart = await window.AndroidBridgePromise.showPrompt(
+        const semesterStart = await window.shiguangBridgePromise.showPrompt(
             "📅 设置开学日期",
             "请输入本学期开学日期",
             semesterInfo.semesterStartDate,
@@ -535,8 +535,8 @@ async function importPresetTimeSlots() {
     // 修复：使用showConfirmDialog而不是showAlert来确保两个按钮都显示
     try {
         // 尝试使用showConfirmDialog（如果有的话）
-        if (window.AndroidBridgePromise && typeof window.AndroidBridgePromise.showConfirmDialog === 'function') {
-            const seasonChoice = await window.AndroidBridgePromise.showConfirmDialog(
+        if (window.shiguangBridgePromise && typeof window.shiguangBridgePromise.showConfirmDialog === 'function') {
+            const seasonChoice = await window.shiguangBridgePromise.showConfirmDialog(
                 "⏰ 选择作息时间",
                 "请根据当前学期选择作息时间：\n\n🌞 夏季（5月1日-9月30日）\n🍂 秋季（10月1日-次年4月30日）",
                 "夏季",
@@ -551,14 +551,14 @@ async function importPresetTimeSlots() {
             console.log(`选择的季节: ${season}，时间段:`, presetTimeSlots);
             
             // 导入时间段
-            const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+            const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
             if (result === true) {
                 console.log("预设时间段导入成功！");
-                window.AndroidBridge.showToast(`✅ ${season === 'summer' ? '夏季' : '秋季'}时间段导入成功！`);
+                window.shiguangBridge.showToast(`✅ ${season === 'summer' ? '夏季' : '秋季'}时间段导入成功！`);
                 return true;
             } else {
                 console.log("预设时间段导入未成功，结果：" + result);
-                window.AndroidBridge.showToast("❌ 时间段导入失败，请查看日志。");
+                window.shiguangBridge.showToast("❌ 时间段导入失败，请查看日志。");
                 return false;
             }
         } 
@@ -567,7 +567,7 @@ async function importPresetTimeSlots() {
             // 方法1：尝试使用showAlert两个按钮 - 修复按钮显示问题
             // 注意：有些AndroidBridge实现中，showAlert的第三个参数是左侧按钮，第四个参数是右侧按钮
             // 确保两个按钮文本都不为空
-            const seasonChoice = await window.AndroidBridgePromise.showAlert(
+            const seasonChoice = await window.shiguangBridgePromise.showAlert(
                 "⏰ 选择作息时间",
                 "请根据当前学期选择作息时间：\n\n🌞 夏季（5月1日-9月30日）\n🍂 秋季（10月1日-次年4月30日）",
                 "夏季",  // 左侧按钮
@@ -599,14 +599,14 @@ async function importPresetTimeSlots() {
             console.log(`选择的季节: ${season}，时间段:`, presetTimeSlots);
             
             // 导入时间段
-            const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+            const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
             if (result === true) {
                 console.log("预设时间段导入成功！");
-                window.AndroidBridge.showToast(`✅ ${season === 'summer' ? '夏季' : '秋季'}时间段导入成功！`);
+                window.shiguangBridge.showToast(`✅ ${season === 'summer' ? '夏季' : '秋季'}时间段导入成功！`);
                 return true;
             } else {
                 console.log("预设时间段导入未成功，结果：" + result);
-                window.AndroidBridge.showToast("❌ 时间段导入失败，请查看日志。");
+                window.shiguangBridge.showToast("❌ 时间段导入失败，请查看日志。");
                 return false;
             }
         }
@@ -616,7 +616,7 @@ async function importPresetTimeSlots() {
         // 方法2：如果两个按钮的方法失败，尝试使用showPrompt让用户输入
         try {
             console.log("尝试使用备用方法选择季节...");
-            const seasonInput = await window.AndroidBridgePromise.showPrompt(
+            const seasonInput = await window.shiguangBridgePromise.showPrompt(
                 "⏰ 选择作息时间",
                 "请输入季节（输入 1 选择夏季，输入 2 选择秋季）：\n\n1 - 夏季 (5月1日-9月30日)\n2 - 秋季 (10月1日-次年4月30日)",
                 "1"
@@ -628,20 +628,20 @@ async function importPresetTimeSlots() {
             }
             
             const presetTimeSlots = getSeasonTimeSlots(season);
-            const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+            const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
             
             if (result === true) {
-                window.AndroidBridge.showToast(`✅ ${season === 'summer' ? '夏季' : '秋季'}时间段导入成功！`);
+                window.shiguangBridge.showToast(`✅ ${season === 'summer' ? '夏季' : '秋季'}时间段导入成功！`);
                 return true;
             }
         } catch (secondError) {
             console.error("备用方法也失败:", secondError);
-            window.AndroidBridge.showToast("导入时间段失败，使用默认夏季时间");
+            window.shiguangBridge.showToast("导入时间段失败，使用默认夏季时间");
             
             // 方法3：使用默认夏季
             const defaultTimeSlots = getSeasonTimeSlots('summer');
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(defaultTimeSlots));
-            window.AndroidBridge.showToast("✅ 默认夏季时间段导入成功");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(defaultTimeSlots));
+            window.shiguangBridge.showToast("✅ 默认夏季时间段导入成功");
             return true;
         }
     }
@@ -649,12 +649,12 @@ async function importPresetTimeSlots() {
 
 async function importSchedule() {
     try {
-        AndroidBridge.showToast("正在提取课表数据...");
+        window.shiguangBridge.showToast("正在提取课表数据...");
         
         const courses = extractCourseData();
         
         if (courses.length === 0) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "⚠️ 提取失败",
                 "未找到课表数据，请确认已在课表页面",
                 "知道了"
@@ -663,7 +663,7 @@ async function importSchedule() {
         }
         
         // 预览
-        const preview = await window.AndroidBridgePromise.showAlert(
+        const preview = await window.shiguangBridgePromise.showAlert(
             "📊 数据预览",
             `共找到 ${courses.length} 门课程\n\n` +
             `示例:\n${courses.slice(0, 5).map(c => 
@@ -678,12 +678,12 @@ async function importSchedule() {
         }
         
         // 导入课程
-        AndroidBridge.showToast("正在导入课程...");
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast("正在导入课程...");
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         
         if (result === true) {
             const semesterDate = await demoPrompt();
-            const configResult = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+            const configResult = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
                 semesterStartDate: semesterDate,
                 semesterTotalWeeks: 20,
                 defaultClassDuration: 45,
@@ -692,27 +692,27 @@ async function importSchedule() {
             }));
             
             if (configResult === true) {
-                AndroidBridge.showToast(`✅ 导入成功！共${courses.length}门课程`);
+                window.shiguangBridge.showToast(`✅ 导入成功！共${courses.length}门课程`);
                 return true;
             }
         }
         
-        AndroidBridge.showToast("❌ 导入失败");
+        window.shiguangBridge.showToast("❌ 导入失败");
         return false;
         
     } catch (error) {
         console.error("导入错误:", error);
-        AndroidBridge.showToast("导入出错: " + error.message);
+        window.shiguangBridge.showToast("导入出错: " + error.message);
         return false;
     }
 }
 
 async function runAllDemosSequentially() {
-    AndroidBridge.showToast("🚀 课表导入助手启动...");
+    window.shiguangBridge.showToast("🚀 课表导入助手启动...");
     
     // 检查页面
     if (!window.location.href.includes('studentHome/expectCourseTable')) {
-        const goToPage = await window.AndroidBridgePromise.showAlert(
+        const goToPage = await window.shiguangBridgePromise.showAlert(
             "页面提示",
             "当前不在课表页面，是否跳转？",
             "跳转",
@@ -726,7 +726,7 @@ async function runAllDemosSequentially() {
     
     const start = await demoAlert();
     if (!start) {
-        AndroidBridge.showToast("已取消");
+        window.shiguangBridge.showToast("已取消");
         return;
     }
     
@@ -736,7 +736,7 @@ async function runAllDemosSequentially() {
     // 导入课表
     await importSchedule();
     
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 导出函数

--- a/resources/HUAYU/huayu.js
+++ b/resources/HUAYU/huayu.js
@@ -215,7 +215,7 @@ function validateDateInput(input) {
 
 async function promptUserToStart() {
 	console.log('JS: 流程开始：显示公告');
-	return await window.AndroidBridgePromise.showAlert(
+	return await window.shiguangBridgePromise.showAlert(
 		'教务系统课表导入',
 		'导入前请确保您已在浏览器中成功登录教务系统。',
 		'好的，开始导入'
@@ -224,7 +224,7 @@ async function promptUserToStart() {
 
 async function confirmAcademicYear(year, semesterName) {
 	console.log('JS: 显示学年学期确认弹窗');
-	return await window.AndroidBridgePromise.showAlert(
+	return await window.shiguangBridgePromise.showAlert(
 		'确认学年学期',
 		'检测到当前为 ' + year + '-' + (parseInt(year) + 1) + ' 学年' + semesterName + '，确认导入该学期课程吗？',
 		'确认导入'
@@ -233,7 +233,7 @@ async function confirmAcademicYear(year, semesterName) {
 
 async function getSemesterStartDate() {
 	console.log('JS: 提示用户输入开学日期');
-	return await window.AndroidBridgePromise.showPrompt(
+	return await window.shiguangBridgePromise.showPrompt(
 		'选择开学日期',
 		'请输入本学期开学日期（格式：YYYY-MM-DD，如2025-09-01）：',
 		'2025-09-01',
@@ -245,7 +245,7 @@ async function getSemesterStartDate() {
  * 通过API请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-	AndroidBridge.showToast('正在请求课表数据...');
+	window.shiguangBridge.showToast('正在请求课表数据...');
 	
 	var semesterCode = getSemesterCode(semesterIndex);
 	var baseUrl = window.location.origin;
@@ -275,34 +275,34 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
 			jsonData = JSON.parse(jsonText);
 		} catch (e) {
 			console.error('JS: JSON解析失败，可能是会话过期:', e);
-			AndroidBridge.showToast('数据返回格式错误，可能是您未成功登录或会话已过期。');
+			window.shiguangBridge.showToast('数据返回格式错误，可能是您未成功登录或会话已过期。');
 			return null;
 		}
 		
 		var courses = parseJsonData(jsonData);
 		if (courses.length === 0) {
-			AndroidBridge.showToast('未找到任何课程数据，请检查所选学年学期是否正确。');
+			window.shiguangBridge.showToast('未找到任何课程数据，请检查所选学年学期是否正确。');
 			return null;
 		}
 		
 		console.log('JS: 课程数据解析成功，共找到 ' + courses.length + ' 门课程');
 		return courses;
 	} catch (error) {
-		AndroidBridge.showToast('请求或解析失败: ' + error.message);
+		window.shiguangBridge.showToast('请求或解析失败: ' + error.message);
 		console.error('JS: Fetch/Parse Error:', error);
 		return null;
 	}
 }
 
 async function saveCourses(parsedCourses) {
-	AndroidBridge.showToast('正在保存 ' + parsedCourses.length + ' 门课程...');
+	window.shiguangBridge.showToast('正在保存 ' + parsedCourses.length + ' 门课程...');
 	console.log('JS: 尝试保存 ' + parsedCourses.length + ' 门课程');
 	try {
-		await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+		await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
 		console.log('JS: 课程保存成功');
 		return true;
 	} catch (error) {
-		AndroidBridge.showToast('课程保存失败: ' + error.message);
+		window.shiguangBridge.showToast('课程保存失败: ' + error.message);
 		console.error('JS: Save Courses Error:', error);
 		return false;
 	}
@@ -318,12 +318,12 @@ async function saveConfig(startDate) {
 		firstDayOfWeek: 1
 	};
 	try {
-		await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-		AndroidBridge.showToast('课表配置更新成功！开学日期：' + startDate);
+		await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+		window.shiguangBridge.showToast('课表配置更新成功！开学日期：' + startDate);
 		console.log('JS: 配置保存成功');
 		return true;
 	} catch (error) {
-		AndroidBridge.showToast('课表配置保存失败: ' + error.message);
+		window.shiguangBridge.showToast('课表配置保存失败: ' + error.message);
 		console.error('JS: Save Config Error:', error);
 		return false;
 	}
@@ -346,25 +346,25 @@ var TimeSlots = [
 async function importPresetTimeSlots(timeSlots) {
 	console.log('JS: 准备导入 ' + timeSlots.length + ' 个预设时间段');
 	try {
-		await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-		AndroidBridge.showToast('预设时间段导入成功！');
+		await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+		window.shiguangBridge.showToast('预设时间段导入成功！');
 		console.log('JS: 预设时间段导入成功');
 	} catch (error) {
-		AndroidBridge.showToast('导入时间段失败: ' + error.message);
+		window.shiguangBridge.showToast('导入时间段失败: ' + error.message);
 		console.error('JS: Save Time Slots Error:', error);
 	}
 }
 
 async function runImportFlow() {
 	if (isLoginPage()) {
-		AndroidBridge.showToast('导入失败：请先登录教务系统！');
+		window.shiguangBridge.showToast('导入失败：请先登录教务系统！');
 		console.log('JS: 检测到当前在登录页面，终止导入');
 		return;
 	}
 	
 	var alertConfirmed = await promptUserToStart();
 	if (!alertConfirmed) {
-		AndroidBridge.showToast('用户取消了导入');
+		window.shiguangBridge.showToast('用户取消了导入');
 		console.log('JS: 用户取消了导入流程');
 		return;
 	}
@@ -379,14 +379,14 @@ async function runImportFlow() {
 	// 让用户确认
 	var confirmResult = await confirmAcademicYear(academicYear, semesterName);
 	if (!confirmResult) {
-		AndroidBridge.showToast('导入已取消');
+		window.shiguangBridge.showToast('导入已取消');
 		console.log('JS: 用户取消确认学年学期');
 		return;
 	}
 	
 	var startDate = await getSemesterStartDate();
 	if (startDate === null) {
-		AndroidBridge.showToast('导入已取消');
+		window.shiguangBridge.showToast('导入已取消');
 		console.log('JS: 获取开学日期失败/取消，流程终止');
 		return;
 	}
@@ -412,9 +412,9 @@ async function runImportFlow() {
 	
 	await importPresetTimeSlots(TimeSlots);
 	
-	AndroidBridge.showToast('课程导入成功，共导入 ' + courses.length + ' 门课程！');
+	window.shiguangBridge.showToast('课程导入成功，共导入 ' + courses.length + ' 门课程！');
 	console.log('JS: 整个导入流程执行完毕并成功');
-	AndroidBridge.notifyTaskCompletion();
+	window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/HUEL/huel_01.js
+++ b/resources/HUEL/huel_01.js
@@ -75,14 +75,14 @@ async function fetchIndexDoc() {
 async function selectTermByUserFromDoc(doc) {
   const { yearData, semesterData } = parseTermOptionsFromDoc(doc);
 
-  const yearIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const yearIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学年',
     JSON.stringify(yearData.options.map(i => i.text)),
     yearData.defaultIndex
   );
   if (yearIndex === null || yearIndex === -1) throw new Error('已取消学年选择');
 
-  const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学期',
     JSON.stringify(semesterData.options.map(i => i.text)),
     semesterData.defaultIndex
@@ -162,7 +162,7 @@ function validateSemesterStartDateInput(input) {
 
 async function selectSemesterStartDate(xnm, xqm) {
   const defaultDate = xqm === '3' ? `${xnm}-09-01` : `${Number(xnm) + 1}-03-01`;
-  const picked = await window.AndroidBridgePromise.showPrompt(
+  const picked = await window.shiguangBridgePromise.showPrompt(
     '选择开学日期',
     '请输入开学日期（YYYY-MM-DD）',
     defaultDate,
@@ -183,26 +183,26 @@ async function run() {
 
     const courses = parseCourses(data);
     if (!courses.length) {
-      AndroidBridge.showToast('导入失败: 未获取到课表数据');
+      window.shiguangBridge.showToast('导入失败: 未获取到课表数据');
       return;
     }
 
     const semesterStartDate = await selectSemesterStartDate(xnm, xqm);
     const allWeeks = courses.flatMap(c => c.weeks);
     const maxWeek = allWeeks.length ? Math.max(...allWeeks) : 20;
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks: maxWeek,
       semesterStartDate: semesterStartDate,
       firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：${courses.length} 门`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：${courses.length} 门`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (e) {
     console.error(e);
-    AndroidBridge.showToast(`导入失败: ${e.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${e.message}`);
   }
 }
 

--- a/resources/HUNNU/hunnu.js
+++ b/resources/HUNNU/hunnu.js
@@ -199,7 +199,7 @@ async function getCourseTableHtml() {
         return iframe.contentDocument.documentElement.outerHTML;
     }
 
-    await window.AndroidBridgePromise.showAlert(
+    await window.shiguangBridgePromise.showAlert(
         "未找到课表",
         "请先点击「我的课表」打开课表页面，然后重新运行导入。",
         "确定"
@@ -208,23 +208,23 @@ async function getCourseTableHtml() {
 }
 
 async function runImportFlow() {
-    AndroidBridge.showToast("湖南师范大学课程导入启动...");
+    window.shiguangBridge.showToast("湖南师范大学课程导入启动...");
 
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "湖南师范大学课表导入",
         "导入前请确保：\n1. 您已登录教务系统\n2. 课表页面已打开且课程数据正常显示",
         "好的，开始导入"
     );
-    if (!confirmed) { AndroidBridge.showToast("导入已取消"); return; }
+    if (!confirmed) { window.shiguangBridge.showToast("导入已取消"); return; }
 
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
 
     const html = await getCourseTableHtml();
 
     // 解析课程
     const rawCourses = parseTaskActivities(html);
     if (rawCourses.length === 0) {
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "解析失败",
             "未能从页面中识别到课程数据。\n请确认课表页面已正确加载。",
             "确定"
@@ -236,29 +236,29 @@ async function runImportFlow() {
 
     // 导入时间段
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
     } catch (e) {
-        AndroidBridge.showToast("导入时间段失败: " + e.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + e.message);
     }
 
     // 保存配置
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks: 20 }));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks: 20 }));
     } catch (e) {
-        AndroidBridge.showToast("保存配置失败: " + e.message);
+        window.shiguangBridge.showToast("保存配置失败: " + e.message);
     }
 
     // 保存课程
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
     } catch (e) {
-        AndroidBridge.showToast("保存课程数据失败: " + e.message);
+        window.shiguangBridge.showToast("保存课程数据失败: " + e.message);
         return;
     }
 
-    AndroidBridge.showToast("课表导入完成！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("课表导入完成！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/HUSE/HUSE.js
+++ b/resources/HUSE/HUSE.js
@@ -277,12 +277,12 @@ async function getCourseConfig() {
  * 在浏览器调试环境中仅打印结果，不调用 AndroidBridge。
  */
 async function runImportFlow() {
-    const isApp = typeof window.AndroidBridgePromise !== 'undefined';
-    const hasToast = typeof window.AndroidBridge !== 'undefined';
+    const isApp = typeof window.shiguangBridgePromise !== 'undefined';
+    const hasToast = typeof window.shiguangBridge !== 'undefined';
 
     try {
         if (hasToast) {
-            AndroidBridge.showToast("正在拉取课表，请稍候...");
+            window.shiguangBridge.showToast("正在拉取课表，请稍候...");
         } else {
             console.log("[HUSE] 开始请求课表页面...");
         }
@@ -314,7 +314,7 @@ async function runImportFlow() {
             const msg = "未解析到任何课程，当前学期可能暂无排课。";
             console.warn("[HUSE] " + msg);
             if (isApp) {
-                await window.AndroidBridgePromise.showAlert("提示", msg, "好的");
+                await window.shiguangBridgePromise.showAlert("提示", msg, "好的");
             } else {
                 alert(msg);
             }
@@ -336,30 +336,30 @@ async function runImportFlow() {
         }
 
         // APP 环境：保存课表配置与作息时间
-        const configSaved = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        const slotsSaved = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        const configSaved = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        const slotsSaved = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         if (!configSaved || !slotsSaved) {
             // 时间配置保存失败不强制中断，继续尝试导入课程
             console.warn("[HUSE] 课表时间配置保存失败，将继续尝试导入课程。");
-            AndroidBridge.showToast("时间配置保存失败，继续导入课程...");
+            window.shiguangBridge.showToast("时间配置保存失败，继续导入课程...");
         }
 
         // APP 环境：保存课程数据
-        const courseSaved = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const courseSaved = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!courseSaved) {
             console.error("[HUSE] 课程数据保存失败。");
-            AndroidBridge.showToast("课程保存失败，请重试！");
+            window.shiguangBridge.showToast("课程保存失败，请重试！");
             return;
         }
 
         console.log(`[HUSE] 导入完成，共写入 ${courses.length} 门课程。`);
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程及作息时间！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程及作息时间！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (err) {
         console.error("[HUSE] 导入流程发生异常：", err);
         if (hasToast) {
-            AndroidBridge.showToast("导入失败：" + err.message);
+            window.shiguangBridge.showToast("导入失败：" + err.message);
         } else {
             alert("导入失败：" + err.message);
         }

--- a/resources/HUST/hust.js
+++ b/resources/HUST/hust.js
@@ -39,7 +39,7 @@ async function selectTerm() {
         term.semester === defaultTerm.semester
     ));
 
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(terms.map((term) => term.label)),
         defaultIndex
@@ -150,37 +150,37 @@ async function fetchCourses(term) {
 }
 
 async function saveCourses(courses) {
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
     const semesterTotalWeeks = courses.reduce((maximum, course) => {  
         const courseMaximum = course.weeks.length > 0 ? Math.max(...course.weeks) : 0;  
         return Math.max(maximum, courseMaximum);  
     }, HUST_DEFAULT_SEMESTER_WEEKS);  
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks }));  
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks }));  
 }
 
 async function runImportFlow() {
     try {
         const term = await selectTerm();
         if (term === null) {
-            AndroidBridge.showToast("已取消导入");
+            window.shiguangBridge.showToast("已取消导入");
             return;
         }
 
-        AndroidBridge.showToast(`正在获取 ${term.label} 课表...`);
+        window.shiguangBridge.showToast(`正在获取 ${term.label} 课表...`);
         const courses = await fetchCourses(term);
         if (courses.length === 0) {
-            AndroidBridge.showToast("该学期未查询到有效课程，请检查学期或登录状态");
+            window.shiguangBridge.showToast("该学期未查询到有效课程，请检查学期或登录状态");
             return;
         }
 
         await saveCourses(courses);
-        AndroidBridge.showToast(`成功导入 ${courses.length} 个课程时段，请按校历设置开学日期`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 个课程时段，请按校历设置开学日期`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
         console.error("课表导入失败:", error);
-        AndroidBridge.showToast(`导入失败：${error?.message ?? error}`);
+        window.shiguangBridge.showToast(`导入失败：${error?.message ?? error}`);
     }
 }
 

--- a/resources/HYNU/hynu_01.js
+++ b/resources/HYNU/hynu_01.js
@@ -125,7 +125,7 @@ async function saveAppConfig() {
         "semesterTotalWeeks": 20,
         "firstDayOfWeek": 1
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -146,7 +146,7 @@ async function saveAppTimeSlots() {
         { "number": 11, "startTime": "21:20", "endTime": "22:05" },
         { "number": 12, "startTime": "22:15", "endTime": "23:00" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -155,12 +155,12 @@ async function saveAppTimeSlots() {
 async function getSelectedSemesterId() {
     const currentYear = new Date().getFullYear();
     // 绑定验证函数 validateYearInput
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput"
     );
     if (!year) return null;
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", JSON.stringify(["第一学期", "第二学期"]), 0
     );
     if (semesterIndex === null) return null;
@@ -172,23 +172,23 @@ async function getSelectedSemesterId() {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "公告",
             "请确保您已在当前页面成功登录教务系统，否则无法获取数据。是否继续？",
             "确认已登录"
         );
         if (!confirmed) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
         const semesterId = await getSelectedSemesterId();
         if (!semesterId) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         
         const response = await fetch("https://hysfjw.hynu.edu.cn/jsxsd/xskb/xskb_list.do", {
             method: "POST",
@@ -201,21 +201,21 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
+            window.shiguangBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
             return;
         }
 
         // 保存数据
-        AndroidBridge.showToast("正在保存配置...");
+        window.shiguangBridge.showToast("正在保存配置...");
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/IMNC/imnc_01.js
+++ b/resources/IMNC/imnc_01.js
@@ -165,41 +165,41 @@ function formatNoArrangementMessage(courses) {
 // 调度流程
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("开始解析课表...");
+        window.shiguangBridge.showToast("开始解析课表...");
         
-        const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+        const alertConfirmed = await window.shiguangBridgePromise.showAlert(
             "导入确认",
             "请确保您目前处于教务系统的“学生课表”显示页面。\n是否立即提取并导入课表？",
             "开始提取"
         );
         
         if (!alertConfirmed) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
         
         let courses = fetchAndParseCourses();
         
         if (!courses || courses.length === 0) {
-            await window.AndroidBridgePromise.showAlert("错误", "未在当前页面找到课表数据，请确认是否处于课表页面，或联系适配开发者。", "好的");
+            await window.shiguangBridgePromise.showAlert("错误", "未在当前页面找到课表数据，请确认是否处于课表页面，或联系适配开发者。", "好的");
             return;
         }
 
         let noArrangementCourses = parseNoArrangementCourses();
         if (noArrangementCourses.length > 0) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "存在未安排课程",
                 formatNoArrangementMessage(noArrangementCourses),
                 "继续"
             );
         }
         
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程块！`);
-        AndroidBridge.notifyTaskCompletion();
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程块！`);
+        window.shiguangBridge.notifyTaskCompletion();
         
     } catch (error) {
-        AndroidBridge.showToast("导入发生错误: " + error.message);
+        window.shiguangBridge.showToast("导入发生错误: " + error.message);
     }
 }
 

--- a/resources/IMU/imu_01.js
+++ b/resources/IMU/imu_01.js
@@ -29,7 +29,7 @@ function formatTime(timeStr) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -40,7 +40,7 @@ async function promptUserToStart() {
  * 获取学年
  */
 async function getAcademicYear() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "学年设置",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         "", 
@@ -53,7 +53,7 @@ async function getAcademicYear() {
  */
 async function selectSemester() {
     const semesters = ["1（第一学期）", "2（第二学期）"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", 
         JSON.stringify(semesters),
         -1 
@@ -69,7 +69,7 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
         const endYear = parseInt(academicYear) + 1;
         const planCode = `${academicYear}-${endYear}-${semesterValue}-2`;
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         const response = await fetch("https://jwxt.imu.edu.cn/student/courseSelect/thisSemesterCurriculum/ajaxStudentSchedule/callback", {
             "headers": { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" },
             "body": `&planCode=${planCode}`,
@@ -123,7 +123,7 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
 
         return { courses, timeSlots };
     } catch (e) {
-        AndroidBridge.showToast("同步失败: " + e.message);
+        window.shiguangBridge.showToast("同步失败: " + e.message);
         return null;
     }
 }
@@ -132,12 +132,12 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
  * 保存数据到应用
  */
 async function saveToApp(result) {
-    const courseSuccess = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
+    const courseSuccess = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
     if (!courseSuccess) return false;
 
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
     
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         semesterTotalWeeks: 20 
     }));
     
@@ -155,14 +155,14 @@ async function runImportFlow() {
     // 获取学年
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
     // 获取学期
     const semesterIndex = await selectSemester();
     if (semesterIndex === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
@@ -172,8 +172,8 @@ async function runImportFlow() {
 
     // 保存并结束
     if (await saveToApp(result)) {
-        AndroidBridge.showToast(`成功导入 ${result.courses.length} 个课程时段`);
-        AndroidBridge.notifyTaskCompletion(); 
+        window.shiguangBridge.showToast(`成功导入 ${result.courses.length} 个课程时段`);
+        window.shiguangBridge.notifyTaskCompletion(); 
     }
 }
 

--- a/resources/IMUT/IMUT_01.js
+++ b/resources/IMUT/IMUT_01.js
@@ -551,7 +551,7 @@ function validateDateFormat(dateString) {
 
 // 弹出日期确认对话框
 async function setStartDate(suggestedDate) {
-    const dateSelection = await window.AndroidBridgePromise.showPrompt(
+    const dateSelection = await window.shiguangBridgePromise.showPrompt(
         "请确认学期起始日期",
         `此日期来自您此学期第一节课日期，如有误，请修改（格式：YYYY-MM-DD）：`,
         suggestedDate || "",
@@ -572,7 +572,7 @@ function validateYearInput(input) {
 
 // 选择学年
 async function getAcademicYear(currentYear) {
-    const yearSelection = await window.AndroidBridgePromise.showPrompt(
+    const yearSelection = await window.shiguangBridgePromise.showPrompt(
         "选择学年", 
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         parseInt(currentYear) + 1980, 
@@ -585,7 +585,7 @@ async function getAcademicYear(currentYear) {
 // 选择学期
 async function selectTerms() {
     const terms = ["春（第二学期）", "夏", "秋（第一学期）"];
-    const termIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const termIndex = await window.shiguangBridgePromise.showSingleSelection(
         "请选择学期",
         JSON.stringify(terms),
         -1
@@ -597,13 +597,13 @@ async function selectTerms() {
 
 // 弹出修改学年和学期对话框
 async function setYearAndTerm(currentYear, currentTerm) {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "请确认学年和学期",
         `当前学年为 ${parseInt(currentYear) + 1980} 年，学期为 ${currentTerm === '3' ? '秋（第一学期）' : currentTerm === '1' ? '春（第二学期）' : '夏'}。是否需要修改？`,
         "我要修改"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("使用默认学年和学期进行导入。");
+        window.shiguangBridge.showToast("使用默认学年和学期进行导入。");
         return false;
     }
     return true;
@@ -613,12 +613,12 @@ async function setYearAndTerm(currentYear, currentTerm) {
 
 async function runImportFlow() {
 
-    AndroidBridge.showToast("即将开始导入课表，请稍候...");
+    window.shiguangBridge.showToast("即将开始导入课表，请稍候...");
 
     // 获取学年学期信息
     const semesterInfo = await getSemesterInfo("http://jw.imut.edu.cn/academic/student/currcourse/currcourse.jsdo");
     if (!semesterInfo) {
-        AndroidBridge.showToast("获取学生信息失败，请重试！");
+        window.shiguangBridge.showToast("获取学生信息失败，请重试！");
         return;
     }
     currentYear = semesterInfo.year; // 当前年份 - 1980
@@ -629,13 +629,13 @@ async function runImportFlow() {
     if (needModify) {
         currentYear = await getAcademicYear(currentYear);
         currentTerm = await selectTerms();
-        AndroidBridge.showToast(`当前年份与学期已修改为：${parseInt(currentYear) + 1980} 年，学期 ${currentTerm === 2 ? '夏' : currentTerm === 1 ? '春（第二学期）' : '秋（第一学期）'}`);
+        window.shiguangBridge.showToast(`当前年份与学期已修改为：${parseInt(currentYear) + 1980} 年，学期 ${currentTerm === 2 ? '夏' : currentTerm === 1 ? '春（第二学期）' : '秋（第一学期）'}`);
     }
 
     // 设置当前学年和学期
     const setResult = await setCurrentYearAndTerm(currentYear, currentTerm);
     if (!setResult) {
-        AndroidBridge.showToast("设置学年和学期失败！");
+        window.shiguangBridge.showToast("设置学年和学期失败！");
         return;
     }
 
@@ -645,13 +645,13 @@ async function runImportFlow() {
     // 获取时段数据
     const timeSlots = await getTimeSlotsArray(timetableUrl);
     if (!timeSlots || timeSlots.length === 0) {
-        AndroidBridge.showToast("获取时间段信息失败，使用默认时间段！");
+        window.shiguangBridge.showToast("获取时间段信息失败，使用默认时间段！");
     }
 
     // 获取并转换课程表数据
     let courses = await convertToTargetFormat(timetableUrl);
     if (courses.length === 0) {
-        AndroidBridge.showToast("获取课程表数据失败，请重试！");
+        window.shiguangBridge.showToast("获取课程表数据失败，请重试！");
         return;
     }
 
@@ -671,7 +671,7 @@ async function runImportFlow() {
         firstCourseDate = await setStartDate(firstCourseDate);
     } catch (err) {
         console.error("用户取消了日期输入:", err);
-        AndroidBridge.showToast("未输入起始日期。");
+        window.shiguangBridge.showToast("未输入起始日期。");
     }
 
     // 获取最大周数
@@ -692,38 +692,38 @@ async function runImportFlow() {
 
     // 提交课程数据
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         const coursesCount = courses.length;
-        AndroidBridge.showToast(`课程导入成功，共导入 ${coursesCount} 门课程！`);
+        window.shiguangBridge.showToast(`课程导入成功，共导入 ${coursesCount} 门课程！`);
     } catch (err) {
         console.error("课程导入失败:", err);
-        AndroidBridge.showToast("课程导入失败：" + err.message);
+        window.shiguangBridge.showToast("课程导入失败：" + err.message);
         return;
     }
 
     // 提交时间段数据
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-        AndroidBridge.showToast("时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        window.shiguangBridge.showToast("时间段导入成功！");
     } catch (err) {
         console.error("时间段导入失败:", err);
-        AndroidBridge.showToast("时间段导入失败：" + err.message);
+        window.shiguangBridge.showToast("时间段导入失败：" + err.message);
         return;
     }
 
     // 提交课表配置
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(coursesConfig));
-        AndroidBridge.showToast("课表配置保存成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(coursesConfig));
+        window.shiguangBridge.showToast("课表配置保存成功！");
     } catch (err) {
         console.error("课表配置保存失败:", err);
-        AndroidBridge.showToast("课表配置保存失败：" + err.message);
+        window.shiguangBridge.showToast("课表配置保存失败：" + err.message);
         return;
     }
 
     // 通知任务完成
     console.log("JS：整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 
 }
 

--- a/resources/JHZYEDU/zhengfang.js
+++ b/resources/JHZYEDU/zhengfang.js
@@ -111,7 +111,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统。\n将自动通过API获取课表数据，无需手动打开课表页面。",
         "好的，开始导入"
@@ -120,7 +120,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 学年应输入 2025）:",
         currentYear,
@@ -130,7 +130,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -152,7 +152,7 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
     
     const apiUrl = "https://jw.jhzyedu.cn/kbcx/xskbcx_cxXsgrkb.html?gnmkdm=N2151";
 
-    AndroidBridge.showToast("正在通过API获取课表数据...");
+    window.shiguangBridge.showToast("正在通过API获取课表数据...");
     
     try {
         const response = await fetch(apiUrl, {
@@ -180,23 +180,23 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
                 }
             }
         }
-        AndroidBridge.showToast("API 返回数据异常，请检查登录状态或学年学期选择。");
+        window.shiguangBridge.showToast("API 返回数据异常，请检查登录状态或学年学期选择。");
         return null;
     } catch (e) {
         console.error("API fetch error: " + e.message);
-        AndroidBridge.showToast("请求课表数据失败，请确认已登录教务系统。");
+        window.shiguangBridge.showToast("请求课表数据失败，请确认已登录教务系统。");
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
+    window.shiguangBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("课程保存失败: " + error.message);
+        window.shiguangBridge.showToast("课程保存失败: " + error.message);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -216,13 +216,13 @@ const TimeSlots = [
 
 async function importPresetTimeSlots(timeSlots) {
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
+        window.shiguangBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     }
@@ -233,20 +233,20 @@ async function runImportFlow() {
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -262,17 +262,17 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
     } catch (error) {
-        AndroidBridge.showToast("课表配置保存失败: " + error.message);
+        window.shiguangBridge.showToast("课表配置保存失败: " + error.message);
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast("课程导入成功，共导入 " + courses.length + " 门课程！");
+    window.shiguangBridge.showToast("课程导入成功，共导入 " + courses.length + " 门课程！");
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/JLU/JLU_01.js
+++ b/resources/JLU/JLU_01.js
@@ -8,7 +8,7 @@
 const PAGE_URL = window.location.href;
 const _idx = PAGE_URL.indexOf("/jwapp/sys/");
 if (_idx < 0) {
-    AndroidBridge.showToast("请先进入(新)教务的「我的课表」页面再导入");
+    window.shiguangBridge.showToast("请先进入(新)教务的「我的课表」页面再导入");
     throw new Error("未在课表页运行，无法定位 VPN 基址");
 }
 const VPN_BASE = PAGE_URL.substring(0, _idx);            // https://vpn.jlu.edu.cn/https/<会话hex>
@@ -98,13 +98,13 @@ function parseSemesterCalendar(rows) {
 
 // ========== UI：开始提示 ==========
 async function promptUserToStart() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "吉林大学课表导入",
         "请确保您已登录吉大 VPN（vpn.jlu.edu.cn），并已进入(新)教务管理系统的「我的课表」页面。\n未停留在课表页可能导致会话失效，无法获取数据。",
         "开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("已取消导入");
+        window.shiguangBridge.showToast("已取消导入");
         return false;
     }
     return true;
@@ -123,7 +123,7 @@ async function selectSemester() {
 
     if (current) {
         // 2. 问用户：导入当前学期 / 选择其他
-        const choice = await window.AndroidBridgePromise.showSingleSelection(
+        const choice = await window.shiguangBridgePromise.showSingleSelection(
             "选择学期",
             JSON.stringify([
                 `导入当前学期：${current.mc}`,
@@ -132,7 +132,7 @@ async function selectSemester() {
             0
         );
         if (choice === null) {
-            AndroidBridge.showToast("已取消导入");
+            window.shiguangBridge.showToast("已取消导入");
             return null;
         }
         if (choice === 0) return current;
@@ -144,22 +144,22 @@ async function selectSemester() {
     try {
         rows = await fetchSemesterList();
     } catch (e) {
-        AndroidBridge.showToast("学期列表获取失败，请检查登录状态");
+        window.shiguangBridge.showToast("学期列表获取失败，请检查登录状态");
         console.error("学期列表获取失败:", e);
         return null;
     }
     if (rows.length === 0) {
-        AndroidBridge.showToast("未获取到学期列表");
+        window.shiguangBridge.showToast("未获取到学期列表");
         return null;
     }
     const labels = rows.map(r => r.MC || r.DM);
-    const idx = await window.AndroidBridgePromise.showSingleSelection(
+    const idx = await window.shiguangBridgePromise.showSingleSelection(
         "选择其他学期",
         JSON.stringify(labels),
         0
     );
     if (idx === null) {
-        AndroidBridge.showToast("已取消导入");
+        window.shiguangBridge.showToast("已取消导入");
         return null;
     }
     return parseSemesterRow(rows[idx]);
@@ -285,23 +285,23 @@ async function saveAll(courses, timeSlots, startDate, totalWeeks) {
         semesterStartDate: startDate,        // "2026-03-09" 或 null
         semesterTotalWeeks: totalWeeks       // 18
     };
-    const cfgOk = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    const cfgOk = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     if (!cfgOk) {
-        AndroidBridge.showToast("课表配置保存失败");
+        window.shiguangBridge.showToast("课表配置保存失败");
         return false;
     }
 
     // 2. 节次时间
-    const slotOk = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    const slotOk = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
     if (!slotOk) {
-        AndroidBridge.showToast("节次时间保存失败");
+        window.shiguangBridge.showToast("节次时间保存失败");
         return false;
     }
 
     // 3. 课程
-    const courseOk = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    const courseOk = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
     if (!courseOk) {
-        AndroidBridge.showToast("课程数据保存失败");
+        window.shiguangBridge.showToast("课程数据保存失败");
         return false;
     }
     return true;
@@ -309,7 +309,7 @@ async function saveAll(courses, timeSlots, startDate, totalWeeks) {
 
 // ========== 主流程 ==========
 async function runImportFlow() {
-    AndroidBridge.showToast("吉林大学课表导入启动...");
+    window.shiguangBridge.showToast("吉林大学课表导入启动...");
     try {
         if (!(await promptUserToStart())) return;
 
@@ -328,7 +328,7 @@ async function runImportFlow() {
         // 4. 课程数据
         const courses = await fetchCourses(sem.xnxqdm);
         if (courses.length === 0) {
-            AndroidBridge.showToast("该学期未查询到课程数据");
+            window.shiguangBridge.showToast("该学期未查询到课程数据");
             return;
         }
 
@@ -346,7 +346,7 @@ async function runImportFlow() {
                     changeNote = `已应用${result.appliedCount}条调课`;
                 } else {
                     // 调课存在但未能自动应用：阻塞提醒用户手动核对
-                    await window.AndroidBridgePromise.showAlert(
+                    await window.shiguangBridgePromise.showAlert(
                         "调课提示",
                         `检测到 ${changes.length} 条调课记录但未能自动应用。已导入原始课表，请对照教务页"调课信息"手动核对，如有出入请联系开发者。`,
                         "知道了"
@@ -368,7 +368,7 @@ async function runImportFlow() {
         }
 
         // 5. 保存
-        AndroidBridge.showToast(`当前学期：${sem.mc}，${finalCourses.length} 条课程${changeNote ? "（" + changeNote + "）" : ""}，正在导入...`);
+        window.shiguangBridge.showToast(`当前学期：${sem.mc}，${finalCourses.length} 条课程${changeNote ? "（" + changeNote + "）" : ""}，正在导入...`);
         const ok = await saveAll(finalCourses, timeSlots, startDate, totalWeeks);
         if (!ok) return;
 
@@ -376,22 +376,22 @@ async function runImportFlow() {
         if (undetermined.length > 0) {
             try {
                 const names = [...new Set(undetermined.map(c => c.KCM).filter(Boolean))].join("、");
-                await window.AndroidBridgePromise.showAlert(
+                await window.shiguangBridgePromise.showAlert(
                     "导入完成",
                     `已导入 ${finalCourses.length} 条课程。\n另有 ${undetermined.length} 门课程上课时间暂未确定，未导入：${names}。\n请关注教务通知，时间确定后重新导入。`,
                     "知道了"
                 );
             } catch (e) {
                 console.warn("未定课程提醒失败:", e);
-                AndroidBridge.showToast(`导入成功！共 ${finalCourses.length} 条课程。`);
+                window.shiguangBridge.showToast(`导入成功！共 ${finalCourses.length} 条课程。`);
             }
         } else {
-            AndroidBridge.showToast(`导入成功！共 ${finalCourses.length} 条课程。`);
+            window.shiguangBridge.showToast(`导入成功！共 ${finalCourses.length} 条课程。`);
         }
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
         console.error("主流程异常:", error);
-        AndroidBridge.showToast("意外错误: " + error.message);
+        window.shiguangBridge.showToast("意外错误: " + error.message);
     }
 }
 

--- a/resources/JNU/jnu_01.js
+++ b/resources/JNU/jnu_01.js
@@ -25,27 +25,27 @@ function checkCurrentPage() {
 //显示是否确认导入课程弹窗
 async function confirmAlert() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "重要提醒",
             "自动加载上课时间段仅支持珠海校区，\n是否确认获取课表？",
             "确认",
         );
         if (confirmed) {
-            AndroidBridge.showToast("正在尝试导入课表...");
+            window.shiguangBridge.showToast("正在尝试导入课表...");
             return true; // 成功时返回 true
         } else {
-            AndroidBridge.showToast("已取消！");
+            window.shiguangBridge.showToast("已取消！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
-        AndroidBridge.showToast("显示弹窗出错！" + error.message);
+        window.shiguangBridge.showToast("显示弹窗出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
 
 //显示到设置中选择开学日期的提醒
 async function setinfoAlert() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "重要提醒",
         "导入课程信息成功，请到设置界面选择当前学期的开学日期",
         "好的"
@@ -59,7 +59,7 @@ async function setinfoAlert() {
 //显示一个是否手动输入学年学期信息的弹窗
 async function confirmGetXNXQAlert() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "重要提醒",
             "自动获取学年学期信息失败，\n是否确认手动输入学年学期信息？",
             "确认",
@@ -67,11 +67,11 @@ async function confirmGetXNXQAlert() {
         if (confirmed) {
             return true; // 成功时返回 true
         } else {
-            AndroidBridge.showToast("已取消！");
+            window.shiguangBridge.showToast("已取消！");
             return false; // 用户取消时返回 false
         }
     } catch (error) {
-        AndroidBridge.showToast("显示弹窗出错！" + error.message);
+        window.shiguangBridge.showToast("显示弹窗出错！" + error.message);
         return false; // 出现错误时也返回 false
     }
 }
@@ -79,7 +79,7 @@ async function confirmGetXNXQAlert() {
 //向用户获取学年信息
 async function getSession() {
     try {
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择学年的起始年（如2025-2026学年的2025）",
             JSON.stringify(yearArr),
             36
@@ -87,11 +87,11 @@ async function getSession() {
         if (selectedIndex !== null && selectedIndex >= 0 && selectedIndex < yearArr.length) {
             return (yearArr[selectedIndex] + '-' + (Number(yearArr[selectedIndex])+1));
         } else {
-            AndroidBridge.showToast("用户取消了选择！");
+            window.shiguangBridge.showToast("用户取消了选择！");
             return -1; // 用户取消时返回-1
         }
     } catch (error) {
-        AndroidBridge.showToast("显示列表出错！" + error.message);
+        window.shiguangBridge.showToast("显示列表出错！" + error.message);
         return -1; // 出现错误时也返回-1
     }
 }
@@ -99,7 +99,7 @@ async function getSession() {
 //向用户获取学期信息
 async function getSemester() {
     try {
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择学期（1-第一学期，2-第二学期）",
             JSON.stringify([1,2]),
             1
@@ -111,11 +111,11 @@ async function getSemester() {
                 return 2;
             }
         } else {
-            AndroidBridge.showToast("用户取消了选择！");
+            window.shiguangBridge.showToast("用户取消了选择！");
             return -1; // 用户取消时返回 -1
         }
     } catch (error) {
-        AndroidBridge.showToast("显示列表出错！" + error.message);
+        window.shiguangBridge.showToast("显示列表出错！" + error.message);
         return -1; // 出现错误时也返回 -1
     }
 }
@@ -140,13 +140,13 @@ async function importPresetTimeSlots() {
     ]
 
     try {
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         if (result === true) {
         } else {
-            AndroidBridge.showToast("时间段导入失败!");
+            window.shiguangBridge.showToast("时间段导入失败!");
         }
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
     }
 }
 
@@ -185,13 +185,13 @@ async function getCourses(xnxqID) {
         }
         const courseData = await response.json();
         if (courseData.datas.xskcb.totalSize === 0){
-            AndroidBridge.showToast("获取到的课表为空课表，请检查学年学期信息！")
+            window.shiguangBridge.showToast("获取到的课表为空课表，请检查学年学期信息！")
             return -1;
         }
-        AndroidBridge.showToast("成功获取课程表信息，共" + courseData.datas.xskcb.totalSize + "门课程");
+        window.shiguangBridge.showToast("成功获取课程表信息，共" + courseData.datas.xskcb.totalSize + "门课程");
         return courseData;
     }catch (error){
-        AndroidBridge.showToast("获取课程表失败:" + error.message);
+        window.shiguangBridge.showToast("获取课程表失败:" + error.message);
         return -1;
     }
 }
@@ -317,12 +317,12 @@ async function saveCourses(courseData) {
                 return -1;
             }
             xnxqID = (session + '-' + semester);
-            AndroidBridge.showToast("你选择的学年学期信息：" + xnxqID);
+            window.shiguangBridge.showToast("你选择的学年学期信息：" + xnxqID);
         }else {
             return -1;
         }
     }else{
-        AndroidBridge.showToast("自动获取到学年学期信息：" + xnxqID);
+        window.shiguangBridge.showToast("自动获取到学年学期信息：" + xnxqID);
     }
 
     const rawResponse = await getCourses(xnxqID);
@@ -334,16 +334,16 @@ async function saveCourses(courseData) {
     const totalWeeksNum = autoGetTotalWeekNum(courses);
 
     try {
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (result === true) {
             //课程导入成功！
             return totalWeeksNum;
         } else {
-            AndroidBridge.showToast("课程导入失败!");
+            window.shiguangBridge.showToast("课程导入失败!");
             return -1
         }
     } catch (error) {
-        AndroidBridge.showToast("导入课程失败: " + error.message);
+        window.shiguangBridge.showToast("导入课程失败: " + error.message);
         return -1;
     }
 
@@ -362,16 +362,16 @@ async function saveConfig(semesterTotalWeeks) {
             "firstDayOfWeek": 1
         };
         const configJsonString = JSON.stringify(courseConfigData);
-        const result = await window.AndroidBridgePromise.saveCourseConfig(configJsonString);
+        const result = await window.shiguangBridgePromise.saveCourseConfig(configJsonString);
         if (result === true) {
             //课表配置导入成功
             return 0;
         } else {
-            AndroidBridge.showToast("课表配置导入失败");
+            window.shiguangBridge.showToast("课表配置导入失败");
             return -1;
         }
     } catch (error) {
-        AndroidBridge.showToast("导入配置失败: " + error.message);
+        window.shiguangBridge.showToast("导入配置失败: " + error.message);
         return -1;
     }
 }
@@ -383,13 +383,13 @@ async function runAllDemosSequentially() {
     //检查是否进入课表界面
     const currentPageNum = checkCurrentPage();
     if(currentPageNum === 1){
-        AndroidBridge.showToast("请登录教务系统");
+        window.shiguangBridge.showToast("请登录教务系统");
         return;
     }else if(currentPageNum === 2) {
-        AndroidBridge.showToast("请进入我的课表界面");
+        window.shiguangBridge.showToast("请进入我的课表界面");
         return;
     }else if(currentPageNum === -1) {
-        AndroidBridge.showToast("未知错误");
+        window.shiguangBridge.showToast("未知错误");
         return;
     }
 
@@ -421,7 +421,7 @@ async function runAllDemosSequentially() {
     }
 
     // 发送最终的生命周期完成信号
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runAllDemosSequentially();

--- a/resources/JSNU/JSNU_01.js
+++ b/resources/JSNU/JSNU_01.js
@@ -156,8 +156,8 @@ function getCourseConfig() {
  */
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在获取课表数据，请稍候...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在获取课表数据，请稍候...");
         } else {
             console.log("正在发起请求获取课表...");
         }
@@ -183,20 +183,20 @@ async function runImportFlow() {
             });
         }
 
-        if (semesters.length > 0 && typeof window.AndroidBridgePromise !== 'undefined') {
-            let selectedIdx = await window.AndroidBridgePromise.showSingleSelection(
+        if (semesters.length > 0 && typeof window.shiguangBridgePromise !== 'undefined') {
+            let selectedIdx = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期", 
                 JSON.stringify(semesters), 
                 defaultIndex
             );
 
             if (selectedIdx === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
 
             if (selectedIdx !== defaultIndex) {
-                AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
+                window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
                 let formData = new URLSearchParams();
                 formData.append('xnxq01id', semesterValues[selectedIdx]);
 
@@ -214,8 +214,8 @@ async function runImportFlow() {
         
         if (courses.length === 0) {
             const errMsg = "未能解析到任何课程，请检查是否暂无排课。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else {
                 alert(errMsg);
             }
@@ -225,27 +225,27 @@ async function runImportFlow() {
         const config = getCourseConfig();
         const timeSlots = getPresetTimeSlots();
 
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【去重成功】课程数据：\n", JSON.stringify(courses, null, 2));
             alert(`解析并去重成功！共获取到 ${courses.length} 门课程。请打开F12查看。`);
             return;
         }
 
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存课程失败，请重试！");
+            window.shiguangBridge.showToast("保存课程失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("导入发生异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("导入发生异常: " + error.message);
         } else {
             console.error("【导入发生异常】", error);
             alert("导入发生异常: " + error.message);

--- a/resources/JSTC/jstc_01.js
+++ b/resources/JSTC/jstc_01.js
@@ -148,38 +148,38 @@ async function fetchAndParseCourses(semesterId) {
  * 流程控制
  */
 async function runImportFlow() {
-    AndroidBridge.showToast("开始拉取学期列表...");
+    window.shiguangBridge.showToast("开始拉取学期列表...");
 
     // 获取学期列表
     const semesters = await fetchSemesters();
     if (!semesters || semesters.length === 0) {
-        AndroidBridge.showToast("获取学期列表失败，请检查登录状态或网络");
+        window.shiguangBridge.showToast("获取学期列表失败，请检查登录状态或网络");
         return;
     }
 
     const labels = semesters.map(s => s.label);
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(labels),
         -1
     );
 
     if (selectedIndex === null || selectedIndex < 0) {
-        AndroidBridge.showToast("操作已取消");
+        window.shiguangBridge.showToast("操作已取消");
         return;
     }
 
     const selectedSemester = semesters[selectedIndex];
 
     // 并行获取元数据与课程表
-    AndroidBridge.showToast("正在拉取课表数据...");
+    window.shiguangBridge.showToast("正在拉取课表数据...");
     const [startDate, courses] = await Promise.all([
         fetchSemesterMetadata(selectedSemester.value),
         fetchAndParseCourses(selectedSemester.value)
     ]);
 
     if (!courses || courses.length === 0) {
-        AndroidBridge.showToast("未查询到有效课程数据");
+        window.shiguangBridge.showToast("未查询到有效课程数据");
         return;
     }
 
@@ -190,31 +190,31 @@ async function runImportFlow() {
     };
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
     } catch (e) {
-        AndroidBridge.showToast("配置保存异常: " + e.message);
+        window.shiguangBridge.showToast("配置保存异常: " + e.message);
         return;
     }
 
     // 保存课程列表
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
     } catch (e) {
-        AndroidBridge.showToast("课程保存异常: " + e.message);
+        window.shiguangBridge.showToast("课程保存异常: " + e.message);
         return;
     }
 
     // 保存预设作息时间
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
     } catch (e) {
-        AndroidBridge.showToast("作息时间保存异常: " + e.message);
+        window.shiguangBridge.showToast("作息时间保存异常: " + e.message);
     }
 
-    AndroidBridge.showToast(`成功导入 ${courses.length} 门课程及作息时间！`);
+    window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程及作息时间！`);
 
     // 任务完成通知
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/JXFU/JXFU_01.js
+++ b/resources/JXFU/JXFU_01.js
@@ -132,8 +132,8 @@ function getCourseConfig() {
  */
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在获取课表配置，请稍候...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在获取课表配置，请稍候...");
         } else {
             console.log("正在请求获取学期列表...");
         }
@@ -166,16 +166,16 @@ async function runImportFlow() {
 
         // 第 2 步：选择学期
         let selectedIdx = defaultIndex;
-        if (typeof window.AndroidBridgePromise !== 'undefined') {
+        if (typeof window.shiguangBridgePromise !== 'undefined') {
             // APP 内原生弹窗
-            let userChoice = await window.AndroidBridgePromise.showSingleSelection(
+            let userChoice = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期", 
                 JSON.stringify(semesters), 
                 defaultIndex
             );
 
             if (userChoice === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
             selectedIdx = userChoice;
@@ -199,8 +199,8 @@ async function runImportFlow() {
         
         let targetXnxqdm = semesterValues[selectedIdx];
 
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表数据...`);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表数据...`);
         } else {
             console.log(`准备拉取学期 [${semesters[selectedIdx]} / 代码: ${targetXnxqdm}] 的课表数据...`);
         }
@@ -214,8 +214,8 @@ async function runImportFlow() {
         
         if (courses.length === 0) {
             const errMsg = "该学期暂无排课数据。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else {
                 alert(errMsg);
             }
@@ -226,7 +226,7 @@ async function runImportFlow() {
         const timeSlots = getPresetTimeSlots();
 
         // 浏览器测试环境，直接打印输出
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【测试成功】课表配置：", config);
             console.log("【测试成功】作息时间：", timeSlots);
             console.log("【测试成功】课程数据：\n", JSON.stringify(courses, null, 2));
@@ -235,21 +235,21 @@ async function runImportFlow() {
         }
 
         // APP 环境保存数据
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存课程失败，请重试！");
+            window.shiguangBridge.showToast("保存课程失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("导入发生异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("导入发生异常: " + error.message);
         } else {
             console.error("【导入发生异常】", error);
             alert("导入发生异常: " + error.message);

--- a/resources/JXNU/JXNU.js
+++ b/resources/JXNU/JXNU.js
@@ -407,7 +407,7 @@ function getTimeSlots() {
 // ---------- 用户交互 ----------
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "江西师范大学 课表导入",
         "请确认：\n1. 已在浏览器中登录教务系统\n2. 已进入学生课表查询页面并选择了正确的学年学期\n3. 已点击【查询】按钮，课表已正常显示\n\n点击确定开始导入。",
         "确定，开始导入"
@@ -415,7 +415,7 @@ async function promptUserToStart() {
 }
 
 async function getTotalWeeks() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "设置本学期总周数",
         "请输入本学期总周数（默认 20，范围 1-55）:",
         "20",
@@ -428,15 +428,15 @@ async function getTotalWeeks() {
 async function run() {
     try {
         const confirmed = await promptUserToStart();
-        if (!confirmed) { AndroidBridge.showToast("用户取消了导入。"); return; }
+        if (!confirmed) { window.shiguangBridge.showToast("用户取消了导入。"); return; }
 
         const weeksInput = await getTotalWeeks();
-        if (weeksInput === null) { AndroidBridge.showToast("导入已取消。"); return; }
+        if (weeksInput === null) { window.shiguangBridge.showToast("导入已取消。"); return; }
         const totalWeeks = parseInt(weeksInput, 10);
-        if (isNaN(totalWeeks) || totalWeeks < 1) { AndroidBridge.showToast("周数设置无效。"); return; }
+        if (isNaN(totalWeeks) || totalWeeks < 1) { window.shiguangBridge.showToast("周数设置无效。"); return; }
         const defaultWeeks = Array.from({ length: totalWeeks }, (_, i) => i + 1);
 
-        AndroidBridge.showToast("正在解析课表数据...");
+        window.shiguangBridge.showToast("正在解析课表数据...");
         const { courses: parsedCourses, html: pageHtml } = parseCourseTableFromCurrentPage();
 
         if (parsedCourses.length === 0) {
@@ -458,7 +458,7 @@ async function run() {
                 detail = '未能在当前页面中找到课表数据。\n' +
                     '请确认已在学生课表查询页面正确选择了学期并点击了【查询】。';
             }
-            await window.AndroidBridgePromise.showAlert("未解析到课程", detail, "确定");
+            await window.shiguangBridgePromise.showAlert("未解析到课程", detail, "确定");
             return;
         }
 
@@ -469,31 +469,31 @@ async function run() {
         }));
 
         try {
-            await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(coursesWithWeeks));
-            AndroidBridge.showToast(`课程数据已导入（共 ${coursesWithWeeks.length} 条）`);
+            await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(coursesWithWeeks));
+            window.shiguangBridge.showToast(`课程数据已导入（共 ${coursesWithWeeks.length} 条）`);
         } catch (saveErr) {
             console.error("[JXNU] 保存课程失败:", saveErr);
-            await window.AndroidBridgePromise.showAlert("保存课程失败", saveErr.message || String(saveErr), "确定");
+            await window.shiguangBridgePromise.showAlert("保存课程失败", saveErr.message || String(saveErr), "确定");
             return;
         }
 
         const timeSlots = getTimeSlots();
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("时间段数据已导入");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("时间段数据已导入");
         } catch (slotErr) {
             console.error("[JXNU] 保存时间段失败:", slotErr);
-            AndroidBridge.showToast(`时间段保存失败：${slotErr.message}`);
+            window.shiguangBridge.showToast(`时间段保存失败：${slotErr.message}`);
         }
 
-        AndroidBridge.showToast("导入完成！");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("导入完成！");
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (err) {
         console.error("[JXNU] 导入流程出错:", err);
         try {
-            await window.AndroidBridgePromise.showAlert("导入失败", `未知错误：${err.message || err}\n\n请联系开发者。`, "确定");
+            await window.shiguangBridgePromise.showAlert("导入失败", `未知错误：${err.message || err}\n\n请联系开发者。`, "确定");
         } catch (_) {}
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     }
 }
 

--- a/resources/JXUST/jxust.js
+++ b/resources/JXUST/jxust.js
@@ -54,7 +54,7 @@ function parseCourseTable(htmlContent) {
 
     const table = doc.getElementById('kbtable');
     if (!table) {
-        AndroidBridge.showToast("错误：未找到课表表格 (id=kbtable)。");
+        window.shiguangBridge.showToast("错误：未找到课表表格 (id=kbtable)。");
         return [];
     }
     
@@ -134,7 +134,7 @@ function parseCourseTable(htmlContent) {
 
 // 网络请求函数
 async function fetchCourseHtml() {
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
     const URL = "https://jw.jxust.edu.cn/jsxsd/xskb/xskb_list.do";
     try {
         const response = await fetch(URL, {
@@ -148,10 +148,10 @@ async function fetchCourseHtml() {
         
         const text = await response.text();
         
-        AndroidBridge.showToast("课表数据获取成功，开始解析...");
+        window.shiguangBridge.showToast("课表数据获取成功，开始解析...");
         return text;
     } catch (error) {
-        AndroidBridge.showToast(`网络请求异常: ${error.message}`);
+        window.shiguangBridge.showToast(`网络请求异常: ${error.message}`);
         return null;
     }
 }
@@ -159,38 +159,38 @@ async function fetchCourseHtml() {
 
 async function importPresetTimeSlots() {
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false; 
     }
 }
 
 async function saveConfig() {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(CourseConfig));
-        AndroidBridge.showToast("课表配置更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(CourseConfig));
+        window.shiguangBridge.showToast("课表配置更新成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
 
 async function saveCourses(parsedCourses) {
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("未解析到任何课程数据，跳过保存。");
+        window.shiguangBridge.showToast("未解析到任何课程数据，跳过保存。");
         return true;
     }
     
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存失败: ${error.message}`);
         return false;
     }
 }
@@ -199,24 +199,24 @@ async function runImportFlow() {
     
     const LOGIN_URL_START = "https://authserver.jxust.edu.cn/authserver/login";
     if (window.location.href.startsWith(LOGIN_URL_START)) {
-        AndroidBridge.showToast("错误：当前页面为登录页，请先完成登录后再尝试导入！");
+        window.shiguangBridge.showToast("错误：当前页面为登录页，请先完成登录后再尝试导入！");
         return;
     }
 
-    const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
         "开始导入",
         "请确保您已登录教务系统",
         "确定"
     );
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     // 获取 HTML
     const htmlContent = await fetchCourseHtml();
     if (htmlContent === null) {
-        AndroidBridge.showToast("导入终止。");
+        window.shiguangBridge.showToast("导入终止。");
         return; 
     }
     
@@ -224,7 +224,7 @@ async function runImportFlow() {
     const parsedCourses = parseCourseTable(htmlContent);
     
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("解析失败或未发现有效课程。导入终止。");
+        window.shiguangBridge.showToast("解析失败或未发现有效课程。导入终止。");
         return;
     }
     
@@ -238,8 +238,8 @@ async function runImportFlow() {
     if (!await saveCourses(parsedCourses)) return;
 
     // 流程成功
-    AndroidBridge.showToast("所有任务已完成！课表已导入成功！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！课表已导入成功！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/JYVTC/jyvtc.js
+++ b/resources/JYVTC/jyvtc.js
@@ -194,7 +194,7 @@ function validateYearInput(input) {
 }
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -204,7 +204,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -215,7 +215,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期 (0)", "第二学期 (1)"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -224,7 +224,7 @@ async function selectSemester() {
 }
 
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     // 0是第一学期，1是第二学期
     const semesterCode = semesterIndex === 0 ? "0" : "1";
@@ -254,7 +254,7 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         const courses = transformSchedule(htmlText);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确。");
             return null;
         }
 
@@ -263,21 +263,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -311,7 +311,7 @@ const SummerTimeSlots = [
 async function selectTimeSlotsType() {
     const timeSlotsOptions = ["非夏季作息", "夏季作息"];
     console.log("JS: 提示用户选择作息时间类型。");
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(timeSlotsOptions),
         0
@@ -323,24 +323,24 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
@@ -348,14 +348,14 @@ async function runImportFlow() {
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -364,7 +364,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -402,9 +402,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(selectedTimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/KSU/ksu_01.js
+++ b/resources/KSU/ksu_01.js
@@ -137,7 +137,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -147,7 +147,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -158,7 +158,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -179,7 +179,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -211,14 +211,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -234,21 +234,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -273,17 +273,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -291,21 +291,21 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -314,7 +314,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -334,10 +334,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -345,9 +345,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/MMPT/mmpt.js
+++ b/resources/MMPT/mmpt.js
@@ -159,14 +159,14 @@ function getMMPTConfig() {
 // 选择校区时间表
 async function selectCampusSchedule() {
     const campuses = Object.keys(MMVT_SCHEDULE_CONFIG);
-    const campusIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const campusIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择校区时间表", 
         JSON.stringify(campuses),
         -1
     );
     
     if (campusIndex === null) {
-        AndroidBridge.showToast("未选择校区，使用南校区时间表");
+        window.shiguangBridge.showToast("未选择校区，使用南校区时间表");
         return MMVT_SCHEDULE_CONFIG['南校区'];
     }
     
@@ -185,7 +185,7 @@ async function selectAcademicYear() {
         years.push(`${year}-${year + 1}`);
     }
     
-    const yearIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const yearIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学年", 
         JSON.stringify(years),
         0 // 默认选择当前学年
@@ -201,7 +201,7 @@ async function selectAcademicYear() {
 // 选择学期
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", 
         JSON.stringify(semesters),
         -1
@@ -253,7 +253,7 @@ async function fetchCourseData() {
         return data;
     } catch (err) {
         console.error("获取课程数据失败:", err);
-        AndroidBridge.showToast("获取课程数据失败：" + err.message);
+        window.shiguangBridge.showToast("获取课程数据失败：" + err.message);
         return null;
     }
 }
@@ -300,17 +300,17 @@ function parseCourseData(responseData) {
 // ====================== 保存课程 ======================
 async function saveCourses(courses) {
     try {
-        const result = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const result = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (result === true) {
-            AndroidBridge.showToast("课程导入成功！");
+            window.shiguangBridge.showToast("课程导入成功！");
             return true;
         } else {
-            AndroidBridge.showToast("课程导入失败，请查看日志！");
+            window.shiguangBridge.showToast("课程导入失败，请查看日志！");
             return false;
         }
     } catch (err) {
         console.error("保存课程失败:", err);
-        AndroidBridge.showToast("保存课程失败：" + err.message);
+        window.shiguangBridge.showToast("保存课程失败：" + err.message);
         return false;
     }
 }
@@ -325,15 +325,15 @@ async function importPresetTimeSlots() {
         console.log(`使用校区时间表: ${campusConfig.name || '未知校区'}`);
         console.log(`时间段数量: ${timeSlots.length}`);
         
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         if (result === true) {
-            AndroidBridge.showToast(`时间段导入成功！共导入${timeSlots.length}个时间段`);
+            window.shiguangBridge.showToast(`时间段导入成功！共导入${timeSlots.length}个时间段`);
         } else {
-            AndroidBridge.showToast("时间段导入失败，请查看日志！");
+            window.shiguangBridge.showToast("时间段导入失败，请查看日志！");
         }
     } catch (err) {
         console.error("时间段导入失败:", err);
-        AndroidBridge.showToast("时间段导入失败：" + err.message);
+        window.shiguangBridge.showToast("时间段导入失败：" + err.message);
     }
 }
 
@@ -341,54 +341,54 @@ async function importPresetTimeSlots() {
 async function runImportFlow() {
     // 检查用户是否已登录
     if (!isUserLoggedIn()) {
-        AndroidBridge.showToast("检测到未登录状态，请先登录后再使用课程导入功能！");
+        window.shiguangBridge.showToast("检测到未登录状态，请先登录后再使用课程导入功能！");
         return;
     }
     
-    AndroidBridge.showToast("课程导入流程即将开始...");
+    window.shiguangBridge.showToast("课程导入流程即将开始...");
 
     try {
         // 1️⃣ 获取课程数据（选择学年学期）
-        AndroidBridge.showToast("请选择学年和学期...");
+        window.shiguangBridge.showToast("请选择学年和学期...");
         
         // 从新系统获取课程数据
         const responseData = await fetchCourseData();
         if (!responseData) {
-            AndroidBridge.showToast("获取课程数据失败！");
+            window.shiguangBridge.showToast("获取课程数据失败！");
             return;
         }
         
         // 2️⃣ 解析课程数据
-        AndroidBridge.showToast("正在解析课程数据...");
+        window.shiguangBridge.showToast("正在解析课程数据...");
         const courses = parseCourseData(responseData);
         if (!courses || courses.length === 0) {
-            AndroidBridge.showToast("未找到课程数据！");
+            window.shiguangBridge.showToast("未找到课程数据！");
             return;
         }
         
         // 3️⃣ 合并重复课程
-        AndroidBridge.showToast("正在合并重复课程...");
+        window.shiguangBridge.showToast("正在合并重复课程...");
         const mergedCourses = mergeDuplicateCourses(courses);
         
         // 4️⃣ 保存课程
-        AndroidBridge.showToast("正在保存课程数据...");
+        window.shiguangBridge.showToast("正在保存课程数据...");
         const saveResult = await saveCourses(mergedCourses);
         if (!saveResult) {
             return;
         }
 
         // 5️⃣ 导入预设时间段（用户选择校区）
-        AndroidBridge.showToast("请选择校区时间表...");
+        window.shiguangBridge.showToast("请选择校区时间表...");
         await importPresetTimeSlots();
 
         // ✅ 只有所有步骤都成功完成，才通知任务完成
-        AndroidBridge.showToast(`课程导入成功，共导入 ${mergedCourses.length} 门课程！`);
+        window.shiguangBridge.showToast(`课程导入成功，共导入 ${mergedCourses.length} 门课程！`);
         console.log("JS：整个导入流程执行完毕并成功。");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
         
     } catch (err) {
         console.error("导入流程失败:", err);
-        AndroidBridge.showToast("导入失败：" + err.message);
+        window.shiguangBridge.showToast("导入失败：" + err.message);
         // ❌ 失败时不调用 notifyTaskCompletion()
     }
 }

--- a/resources/NBUT/nbut.js
+++ b/resources/NBUT/nbut.js
@@ -15,12 +15,12 @@ async function checkLoginEnvironment() {
     const targetUrl = "http://jwxt.nbut.edu.cn/"
 
     if (!currentUrl.includes(targetUrl)) {
-        AndroidBridge.showToast("不处于教务系统网站，自动为你跳转");
+        window.shiguangBridge.showToast("不处于教务系统网站，自动为你跳转");
         window.location.href = loginUrl;
         return false;
     } 
     if (currentUrl.includes(loginUrl)) {
-        AndroidBridge.showToast("请先登录教务系统再进行导入");
+        window.shiguangBridge.showToast("请先登录教务系统再进行导入");
         return false;
     }
     return true; 
@@ -246,7 +246,7 @@ async function runImportFlow() {
         console.log("未找到有效课程");
         return;
     }
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
     // 获取，解析，保存时间段
     const time = await fetchPresetTimeSlots(params.xn, params.xq);
@@ -254,17 +254,17 @@ async function runImportFlow() {
         console.log("未找到有效时间段");
         return;
     }
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(time));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(time));
 
     const config = await fetchConfig(params);
     if(!config){
         console.log("未找到学校全局配置")
         return;
     }
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     // 完成
     console.log('导入成功')
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动

--- a/resources/NCUT/ncut_01.js
+++ b/resources/NCUT/ncut_01.js
@@ -98,9 +98,9 @@
         return courses;
     }
 
-    async function saveCourses(c){ try{await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(c));}catch(e){} }
-    async function saveTimeSlots(s){ try{await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(s));}catch(e){} }
-    async function saveConfig(c){ try{await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(c));}catch(e){} }
+    async function saveCourses(c){ try{await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(c));}catch(e){} }
+    async function saveTimeSlots(s){ try{await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(s));}catch(e){} }
+    async function saveConfig(c){ try{await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(c));}catch(e){} }
 
     function waitForScheduleDoc(maxWait=15000) {
         const start=Date.now();
@@ -124,7 +124,7 @@
             await saveConfig(config);
             await saveTimeSlots(timeSlots);
             await saveCourses(courses);
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.notifyTaskCompletion();
         } catch(e) {}
     }
 

--- a/resources/NEAU/NEAU_01.js
+++ b/resources/NEAU/NEAU_01.js
@@ -39,8 +39,8 @@ function parseWeeks(weekStr) {
  */
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在通过数据接口获取课表...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在通过数据接口获取课表...");
         } else {
             console.log("正在请求 URP 内部数据接口...");
         }
@@ -58,8 +58,8 @@ async function runImportFlow() {
         // URP 的课程数据存放在 xkxx 这个数组的第0个对象里
         if (!data || !data.xkxx || !data.xkxx[0]) {
             const errMsg = "未获取到有效的课表数据，可能是当前学期暂无排课。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else {
                 alert(errMsg);
             }
@@ -141,7 +141,7 @@ async function runImportFlow() {
         };
 
         // 3. 浏览器测试环境，直接打印输出
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【URP系统测试成功】提取的课程数据：\n", JSON.stringify(parsedCourses, null, 2));
             if (timeSlots.length > 0) {
                 console.log("【URP系统测试成功】提取到的作息时间：\n", JSON.stringify(timeSlots, null, 2));
@@ -153,25 +153,25 @@ async function runImportFlow() {
         }
 
         // 4. APP 环境保存数据
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
         
         // 将格式化后的标准作息时间交给 APP 进行保存
         if (timeSlots.length > 0) {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         }
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存课程失败，请重试！");
+            window.shiguangBridge.showToast("保存课程失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 节课程！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 节课程！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("导入发生异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("导入发生异常: " + error.message);
         } else {
             console.error("【导入发生异常】", error);
             alert("导入发生异常: " + error.message);

--- a/resources/NENU/NENU_01.js
+++ b/resources/NENU/NENU_01.js
@@ -14,8 +14,8 @@ function parseWeeks(weekStr) {
 
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在获取作息时间与学期列表...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在获取作息时间与学期列表...");
         } else {
             console.log("【1/4】正在请求 week.page 获取学期和作息时间...");
         }
@@ -63,12 +63,12 @@ async function runImportFlow() {
 
         // 2. 选择学期
         let selectedIdx = defaultIndex;
-        if (typeof window.AndroidBridgePromise !== 'undefined') {
-            let userChoice = await window.AndroidBridgePromise.showSingleSelection(
+        if (typeof window.shiguangBridgePromise !== 'undefined') {
+            let userChoice = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期", JSON.stringify(semesters), defaultIndex
             );
             if (userChoice === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
             selectedIdx = userChoice;
@@ -82,8 +82,8 @@ async function runImportFlow() {
         }
 
         const targetXnxqdm = semesterValues[selectedIdx];
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 数据...`);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 数据...`);
         }
 
         // 3. 请求课表接口
@@ -107,8 +107,8 @@ async function runImportFlow() {
         
         if (apiJson.data.length === 0) {
             const errMsg = "该学期暂无排课数据。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else alert(errMsg);
             return;
         }
@@ -160,7 +160,7 @@ async function runImportFlow() {
         const config = { "defaultClassDuration": 45, "defaultBreakDuration": 10 };
 
         // 浏览器测试输出
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【修正后的正常网格时间】", standardTimeSlots);
             console.log(`【提取的课程 (${uniqueCourses.length}门)】\n`, JSON.stringify(uniqueCourses, null, 2));
             alert("解析成功！已将中午课程转为无缝自定义时间。请看F12。");
@@ -168,20 +168,20 @@ async function runImportFlow() {
         }
 
         // 5. 保存到APP
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(standardTimeSlots));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(standardTimeSlots));
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(uniqueCourses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(uniqueCourses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存失败，请重试！");
+            window.shiguangBridge.showToast("保存失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${uniqueCourses.length} 节课程！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${uniqueCourses.length} 节课程！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') AndroidBridge.showToast("异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') window.shiguangBridge.showToast("异常: " + error.message);
         else alert("异常: " + error.message);
     }
 }

--- a/resources/NEU/neu.js
+++ b/resources/NEU/neu.js
@@ -69,10 +69,10 @@ async function showSemesterSelection() {
 async function showCampusSelection() {
     const campuses = ["南湖校区", "浑南校区"];
     try {
-        const idx = await window.AndroidBridgePromise.showSingleSelection("选择你所在的校区", JSON.stringify(campuses), 2);
+        const idx = await window.shiguangBridgePromise.showSingleSelection("选择你所在的校区", JSON.stringify(campuses), 2);
         return idx !== -1 ? campuses[idx] : false;
     } catch(e) {
-        AndroidBridge.showToast("显示校区列表出错：" + e.message);
+        window.shiguangBridge.showToast("显示校区列表出错：" + e.message);
         return false;
     }
 }
@@ -324,7 +324,7 @@ async function fetchCoursesFromAPI(semesterCode, retries=2) {
  * @param {Array<object>} lessons 课程对象数组
  */
 async function SaveCourses(lessons) {
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(lessons));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(lessons));
 }
 
 /**
@@ -335,7 +335,7 @@ async function importTimeSlotsByCampus(campus) {
     const hunNan = [{"number":1,"startTime":"08:30","endTime":"09:15"},{"number":2,"startTime":"09:25","endTime":"10:10"},{"number":3,"startTime":"10:30","endTime":"11:15"},{"number":4,"startTime":"11:25","endTime":"12:10"},{"number":5,"startTime":"14:00","endTime":"14:45"},{"number":6,"startTime":"14:55","endTime":"15:40"},{"number":7,"startTime":"16:00","endTime":"16:45"},{"number":8,"startTime":"16:55","endTime":"17:40"},{"number":9,"startTime":"18:30","endTime":"19:15"},{"number":10,"startTime":"19:25","endTime":"20:10"},{"number":11,"startTime":"20:30","endTime":"21:15"},{"number":12,"startTime":"21:15","endTime":"22:10"}];
     const nanHu = [{"number":1,"startTime":"08:00","endTime":"08:45"},{"number":2,"startTime":"08:55","endTime":"09:40"},{"number":3,"startTime":"10:00","endTime":"10:45"},{"number":4,"startTime":"10:55","endTime":"11:40"},{"number":5,"startTime":"14:00","endTime":"14:45"},{"number":6,"startTime":"14:55","endTime":"15:40"},{"number":7,"startTime":"16:00","endTime":"16:45"},{"number":8,"startTime":"16:55","endTime":"17:40"},{"number":9,"startTime":"18:30","endTime":"19:15"},{"number":10,"startTime":"19:25","endTime":"20:10"},{"number":11,"startTime":"20:20","endTime":"21:05"},{"number":12,"startTime":"21:15","endTime":"22:00"}];
     const slots = campus === "南湖校区" ? nanHu : hunNan;
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(slots));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(slots));
 }
 
 /**
@@ -343,7 +343,7 @@ async function importTimeSlotsByCampus(campus) {
  */
 async function SaveConfig() {
     const cfg = { semesterTotalWeeks:18, defaultClassDuration:45, defaultBreakDuration:10, firstDayOfWeek:7 };
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(cfg));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(cfg));
 }
 
 /**
@@ -351,46 +351,46 @@ async function SaveConfig() {
  * 最后通知Android任务完成
  */
 async function runAllDemosSequentially() {
-    AndroidBridge.showToast("开始导入课表...");
+    window.shiguangBridge.showToast("开始导入课表...");
     const campus = await showCampusSelection();
-    if (!campus) { AndroidBridge.showToast("已取消导入"); return; }
+    if (!campus) { window.shiguangBridge.showToast("已取消导入"); return; }
     const semester = await showSemesterSelection();
-    if (!semester) { AndroidBridge.showToast("已取消导入"); return; }
+    if (!semester) { window.shiguangBridge.showToast("已取消导入"); return; }
     
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
     let lessons;
     try {
         lessons = await fetchCoursesFromAPI(semester);
-        if (!lessons.length) { AndroidBridge.showToast("未获取到任何课程"); return; }
+        if (!lessons.length) { window.shiguangBridge.showToast("未获取到任何课程"); return; }
         console.log(`获取到 ${lessons.length} 门课程`);
     } catch(e) {
-        AndroidBridge.showToast("获取课表失败: "+e.message);
+        window.shiguangBridge.showToast("获取课表失败: "+e.message);
         return;
     }
     await SaveCourses(lessons);
     await importTimeSlotsByCampus(campus);
     await SaveConfig();
-    AndroidBridge.showToast("课表导入完成！");
+    window.shiguangBridge.showToast("课表导入完成！");
     
     const importExams = await askImportExams();
     if (importExams) {
-        AndroidBridge.showToast("正在获取考试数据...");
+        window.shiguangBridge.showToast("正在获取考试数据...");
         try {
             const examLessons = await fetchExamsFromAPI(semester);
             if (examLessons.length === 0) {
-                AndroidBridge.showToast("未获取到考试数据");
+                window.shiguangBridge.showToast("未获取到考试数据");
             } else {
                 const allLessons = [...lessons, ...examLessons];
                 await SaveCourses(allLessons);
-                AndroidBridge.showToast(`已导入 ${examLessons.length} 条考试记录（合并至课表）`);
+                window.shiguangBridge.showToast(`已导入 ${examLessons.length} 条考试记录（合并至课表）`);
             }
         } catch(e) {
-            AndroidBridge.showToast("导入考试失败: "+e.message);
+            window.shiguangBridge.showToast("导入考试失败: "+e.message);
             console.error(e);
         }
     }
     
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动主流程

--- a/resources/NEUQ/neuq.js
+++ b/resources/NEUQ/neuq.js
@@ -275,7 +275,7 @@
 
     async function runImportFlow() {
         // 确保桥接可用
-        if (!window.AndroidBridgePromise) {
+        if (!window.shiguangBridgePromise) {
             throw new Error("AndroidBridgePromise 不可用，无法进行导入交互。");
         }
 
@@ -287,7 +287,7 @@
         });
         const params = parseEntryParams(entryHtml);
         if (!params.studentId || !params.tagId) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "参数探测失败",
                 "未能识别学生 ID 或学期组件 tagId，请确认已登录后重试。",
                 "确定"
@@ -306,17 +306,17 @@
             throw new Error("学期列表为空，无法继续导入。");
         }
         const recentSemesters = allSemesters;
-        const selectIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择导入学期",
             JSON.stringify(recentSemesters.map((s) => s.name || s.id)),
             -1
         );
         if (selectIndex === null) {
-            AndroidBridge.showToast("已取消导入");
+            window.shiguangBridge.showToast("已取消导入");
             return;
         }
         const selectedSemester = recentSemesters[selectIndex];
-        AndroidBridge.showToast("正在获取课表数据...");
+        window.shiguangBridge.showToast("正在获取课表数据...");
 
         // 3. 拉取并解析课表
         const courseHtml = await requestText(`${BASE}/eams/courseTableForStd!courseTable.action?sf_request_type=ajax`, {
@@ -334,7 +334,7 @@
         const courses = parseCoursesFromTaskActivityScript(courseHtml);
         if (courses.length === 0) {
             const debugInfo = extractCourseHtmlDebugInfo(courseHtml);
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "解析失败",
                 `未能从课表响应中识别到课程。\n响应长度: ${debugInfo.responseLength}\n包含 TaskActivity: ${debugInfo.hasTaskActivity}`,
                 "确定"
@@ -343,11 +343,11 @@
         }
 
         // 4. 保存结果
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(getPresetTimeSlots()));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(getPresetTimeSlots()));
 
-        AndroidBridge.showToast(`导入成功，共 ${courses.length} 条课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`导入成功，共 ${courses.length} 条课程`);
+        window.shiguangBridge.notifyTaskCompletion();
     }
 
     (async function bootstrap() {
@@ -355,7 +355,7 @@
             await runImportFlow();
         } catch (error) {
             console.error("导入流程失败:", error);
-            AndroidBridge.showToast("自动探测失败，请检查教务连接");
+            window.shiguangBridge.showToast("自动探测失败，请检查教务连接");
         }
     })();
 })();

--- a/resources/NIIT/niit.js
+++ b/resources/NIIT/niit.js
@@ -76,7 +76,7 @@ function parseCourse(r) {
 
 // 主流程
 (async function () {
-    if (!(window.AndroidBridgePromise && window.AndroidBridgePromise.saveImportedCourses)) return;
+    if (!(window.shiguangBridgePromise && window.shiguangBridgePromise.saveImportedCourses)) return;
 
     var datas = await fetchCourseRows();
     var rows = pluckRows(datas);
@@ -100,8 +100,8 @@ function parseCourse(r) {
     var totalWeeks = 0;
     for (var j = 0; j < rows.length; j++) totalWeeks = Math.max(totalWeeks, String(rows[j].SKZC || "").length);
 
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(PRESET_TIME_SLOTS));
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({ semesterStartDate: null, semesterTotalWeeks: totalWeeks || 20, firstDayOfWeek: 1 }));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-    try { window.AndroidBridge.notifyTaskCompletion(); } catch (e) { }
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(PRESET_TIME_SLOTS));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({ semesterStartDate: null, semesterTotalWeeks: totalWeeks || 20, firstDayOfWeek: 1 }));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    try { window.shiguangBridge.notifyTaskCompletion(); } catch (e) { }
 })();

--- a/resources/NJFU/njfu_01.js
+++ b/resources/NJFU/njfu_01.js
@@ -44,8 +44,8 @@ function cleanPosition(position) {
 }
 
 function showToast(message) {
-    if (typeof window.AndroidBridge !== "undefined") {
-        AndroidBridge.showToast(message);
+    if (typeof window.shiguangBridge !== "undefined") {
+        window.shiguangBridge.showToast(message);
     } else {
         console.log(message);
     }
@@ -275,11 +275,11 @@ async function fetchTermDoc(termValue) {
 
 async function pickTerm(doc) {
     const { labels, values, defaultIndex } = parseSemesterOptions(doc);
-    if (!labels.length || typeof window.AndroidBridgePromise === "undefined") {
+    if (!labels.length || typeof window.shiguangBridgePromise === "undefined") {
         return { doc, termLabel: labels[defaultIndex] || "" };
     }
 
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "请选择要导入的学期",
         JSON.stringify(labels),
         defaultIndex
@@ -301,7 +301,7 @@ async function saveToApp(courses, primaryCampus) {
     const allWeeks = courses.flatMap((course) => course.weeks || []);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    if (typeof window.AndroidBridgePromise === "undefined") {
+    if (typeof window.shiguangBridgePromise === "undefined") {
         console.log("Primary campus:", primaryCampus);
         console.log("Time slots:", timeSlots);
         console.log("Courses:", courses);
@@ -309,13 +309,13 @@ async function saveToApp(courses, primaryCampus) {
         return;
     }
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         semesterTotalWeeks,
         firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
     const appCourses = courses.map(({ campus, ...course }) => course);
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(appCourses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(appCourses));
 }
 
 async function runImportFlow() {
@@ -337,8 +337,8 @@ async function runImportFlow() {
         const message = `导入完成：${primaryCampus}${termLabel ? ` ${termLabel}` : ""}`;
 
         showToast(message);
-        if (typeof window.AndroidBridge !== "undefined") {
-            AndroidBridge.notifyTaskCompletion();
+        if (typeof window.shiguangBridge !== "undefined") {
+            window.shiguangBridge.notifyTaskCompletion();
         }
     } catch (error) {
         console.error(error);

--- a/resources/NJNU/njnu.js
+++ b/resources/NJNU/njnu.js
@@ -95,7 +95,7 @@ async function fetchSemesterStartDate(academicYear, semesterCode) {
         
     } catch (error) {
         console.error('获取日期失败:', error);
-        AndroidBridge.showToast("获取错误，需要手动设置开学日期");
+        window.shiguangBridge.showToast("获取错误，需要手动设置开学日期");
         return null;
     }
 }
@@ -164,7 +164,7 @@ function applyCourseChanges(parsedCourses, rawChanges) {
     }
     
     if (successCount > 0) {
-        AndroidBridge.showToast(`已应用 ${successCount} 条调课/停课变更，获得实际课表。`);
+        window.shiguangBridge.showToast(`已应用 ${successCount} 条调课/停课变更，获得实际课表。`);
     }
     
     return parsedCourses.map(c => {
@@ -178,13 +178,13 @@ function applyCourseChanges(parsedCourses, rawChanges) {
 
 
 async function promptUserToStart() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "重要通知：南京师范大学课表导入",
         "本流程将通过教务系统接口获取您的个人课表。\n重要提示:\n导入前请确保您已在浏览器中成功登录教务系统，且未关闭登录窗口，确认当前页面有显示你想要获取的学期的课表，不然获取不了数据",
         "好的，开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return null;
     }
     return true;
@@ -192,7 +192,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear();
-    const yearSelection = await window.AndroidBridgePromise.showPrompt(
+    const yearSelection = await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的学年（例如 2025-2026学年，无论你是上学期还是下学期，都请输入2025哦）:",
         String(currentYear), 
@@ -203,7 +203,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["1 (秋季学期/上学期)", "2 (春季学期/下学期)"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -229,14 +229,14 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         const response = await fetch(courseUrl, { "headers": headers, "body": courseBody, "method": "POST", "credentials": "include" });
         rawCourseData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求课表 API 失败，请检查网络和登录状态,以及是否跳转到课表页面");
+        window.shiguangBridge.showToast("请求课表 API 失败，请检查网络和登录状态,以及是否跳转到课表页面");
         console.error("Fetch Course Error:", e);
         return null;
     }
 
     const rawCourses = rawCourseData?.datas?.cxxszhxqkb?.rows || [];
     if (rawCourses.length === 0) {
-        AndroidBridge.showToast("该学期未查询到您的课程数据。");
+        window.shiguangBridge.showToast("该学期未查询到您的课程数据。");
         return null;
     }
     let parsedCourses = rawCourses.map(c => parseSingleCourse(c)).filter(c => c !== null);
@@ -248,7 +248,7 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         const response = await fetch(changeUrl, { "headers": headers, "body": changeBody, "method": "POST", "credentials": "include" });
         rawChangeData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求调课 API 失败，将使用未调整的课表数据。");
+        window.shiguangBridge.showToast("请求调课 API 失败，将使用未调整的课表数据。");
         console.error("Fetch Change Error:", e);
     }
     
@@ -275,15 +275,15 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
 
 async function saveCourses(parsedCourses) {
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("没有有效的课程数据可供保存。");
+        window.shiguangBridge.showToast("没有有效的课程数据可供保存。");
         return true;
     }
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存课程数据失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存课程数据失败: ${error.message}`);
         return false;
     }
 }
@@ -292,7 +292,7 @@ async function saveCourses(parsedCourses) {
  * 导入预设时间段数据
  */
 async function importPresetTimeSlots() {
-    AndroidBridge.showToast("正在导入预设节次时间...");
+    window.shiguangBridge.showToast("正在导入预设节次时间...");
     
     const presetTimeSlots = [
         { "number": 1, "startTime": "08:00", "endTime": "08:40" },
@@ -310,22 +310,22 @@ async function importPresetTimeSlots() {
     ];
 
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
         return true; 
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false; 
     }
 }
 
 async function saveConfig(configData) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
-        AndroidBridge.showToast("课表配置更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        window.shiguangBridge.showToast("课表配置更新成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
@@ -333,7 +333,7 @@ async function saveConfig(configData) {
 // 主流程入口
 
 async function runImportFlow() {
-    AndroidBridge.showToast("南京师范大学课程导入流程启动...");
+    window.shiguangBridge.showToast("南京师范大学课程导入流程启动...");
 
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
@@ -342,13 +342,13 @@ async function runImportFlow() {
     // 2. 获取用户输入参数 (学年和学期)。
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     
     const semesterCode = await selectSemester();
     if (semesterCode === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -368,8 +368,8 @@ async function runImportFlow() {
     if (!saveResult) return;
 
     // 7. 流程完全成功，发送结束信号。
-    AndroidBridge.showToast("所有任务已完成！课表导入成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("所有任务已完成！课表导入成功。");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/NJTECH/njtech.js
+++ b/resources/NJTECH/njtech.js
@@ -126,7 +126,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -136,7 +136,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -147,7 +147,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         -1
@@ -202,19 +202,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         console.error(`Request failed: ${targetUrl}`, e);
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -238,17 +238,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -258,14 +258,14 @@ async function runImportFlow() {
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -274,7 +274,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -294,10 +294,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -305,9 +305,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/NWPU/nwpu_01.js
+++ b/resources/NWPU/nwpu_01.js
@@ -107,14 +107,14 @@ async function getSemestersAndStudentId() {
  */
 async function getCourseData(semesterId, studentId) {
     console.log("[NWPU] 正在获取课程数据...");
-    AndroidBridge.showToast("正在同步课表...");
+    window.shiguangBridge.showToast("正在同步课表...");
     try {
         var url = "/student/for-std/course-table/semester/" + semesterId + "/print-data/" + studentId;
         var data = await request(url);
         return JSON.parse(data);
     } catch (e) {
         console.error("[NWPU] 获取课程数据失败: " + e.message);
-        AndroidBridge.showToast("获取课程数据失败: " + e.message);
+        window.shiguangBridge.showToast("获取课程数据失败: " + e.message);
         return null;
     }
 }
@@ -286,12 +286,12 @@ async function saveTimeSlots(timeSlots) {
     }
     try {
         console.log("[NWPU] 正在保存时间段...");
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-        AndroidBridge.showToast("成功导入 " + timeSlots.length + " 个时间段");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        window.shiguangBridge.showToast("成功导入 " + timeSlots.length + " 个时间段");
         return true;
     } catch (e) {
         console.error("[NWPU] 保存时间段失败: " + e.message);
-        AndroidBridge.showToast("保存时间段失败: " + e.message);
+        window.shiguangBridge.showToast("保存时间段失败: " + e.message);
         return false;
     }
 }
@@ -302,12 +302,12 @@ async function saveTimeSlots(timeSlots) {
 async function saveConfig(config) {
     try {
         console.log("[NWPU] 正在保存课表配置...");
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast("课表配置导入成功");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast("课表配置导入成功");
         return true;
     } catch (e) {
         console.error("[NWPU] 保存配置失败: " + e.message);
-        AndroidBridge.showToast("保存配置失败: " + e.message);
+        window.shiguangBridge.showToast("保存配置失败: " + e.message);
         return false;
     }
 }
@@ -317,17 +317,17 @@ async function saveConfig(config) {
  */
 async function saveCourses(courses) {
     if (courses.length === 0) {
-        AndroidBridge.showToast("没有课程数据需要导入");
+        window.shiguangBridge.showToast("没有课程数据需要导入");
         return true;
     }
     try {
         console.log("[NWPU] 正在保存课程数据...");
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast("成功导入 " + courses.length + " 个课程条目");
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast("成功导入 " + courses.length + " 个课程条目");
         return true;
     } catch (e) {
         console.error("[NWPU] 保存课程失败: " + e.message);
-        AndroidBridge.showToast("保存课程失败: " + e.message);
+        window.shiguangBridge.showToast("保存课程失败: " + e.message);
         return false;
     }
 }
@@ -338,22 +338,22 @@ async function saveCourses(courses) {
 async function runImportFlow() {
     try {
         // 1. 显示导入说明
-        var confirmed = await window.AndroidBridgePromise.showAlert(
+        var confirmed = await window.shiguangBridgePromise.showAlert(
             "西北工业大学课表导入",
             "导入前请确保您已在浏览器中登录教务系统（jwxt.nwpu.edu.cn）。\n\n" +
             "本适配将自动获取学期信息、时间段和课程数据。",
             "开始导入"
         );
         if (!confirmed) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
         // 2. 获取学期列表和学生 ID（从同一页面提取）
-        AndroidBridge.showToast("正在获取学期列表...");
+        window.shiguangBridge.showToast("正在获取学期列表...");
         var pageData = await getSemestersAndStudentId();
         if (!pageData.studentId) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "导入失败",
                 "未能获取学生 ID，请确认您已登录教务系统。",
                 "确定"
@@ -361,7 +361,7 @@ async function runImportFlow() {
             return;
         }
         if (pageData.semesters.length === 0) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "导入失败",
                 "未能获取学期列表，请刷新页面后重试。",
                 "确定"
@@ -381,13 +381,13 @@ async function runImportFlow() {
         var selectedSemester = null;
 
         while (true) {
-            var selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+            var selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
                 "选择学期",
                 JSON.stringify(semesterNames),
                 0
             );
             if (selectedIndex === null || selectedIndex < 0 || selectedIndex >= semesters.length) {
-                AndroidBridge.showToast("导入已取消");
+                window.shiguangBridge.showToast("导入已取消");
                 return;
             }
             selectedSemester = semesters[selectedIndex];
@@ -404,13 +404,13 @@ async function runImportFlow() {
             }
 
             // 无数据，弹窗提示后重新选择
-            var retry = await window.AndroidBridgePromise.showAlert(
+            var retry = await window.shiguangBridgePromise.showAlert(
                 "无课程数据",
                 "「" + selectedSemester.name + "」没有课程数据，请选择其他学期。",
                 "重新选择"
             );
             if (!retry) {
-                AndroidBridge.showToast("导入已取消");
+                window.shiguangBridge.showToast("导入已取消");
                 return;
             }
         }
@@ -418,7 +418,7 @@ async function runImportFlow() {
         console.log("[NWPU] 获取到 " + activities.length + " 条课程活动");
 
         // 5. 获取学期信息（开始日期、结束日期）
-        AndroidBridge.showToast("正在获取学期信息...");
+        window.shiguangBridge.showToast("正在获取学期信息...");
         var semesterInfo = await getSemesterInfo(selectedSemester.id);
         console.log("[NWPU] 学期开始: " + (semesterInfo.startDate || "未知") + ", 结束: " + (semesterInfo.endDate || "未知"));
 
@@ -442,12 +442,12 @@ async function runImportFlow() {
         if (!courseResult) return;
 
         // 完成
-        AndroidBridge.showToast("课表导入完成！");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("课表导入完成！");
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (e) {
         console.error("[NWPU] 导入异常: " + e.message);
-        AndroidBridge.showToast("导入异常: " + e.message);
+        window.shiguangBridge.showToast("导入异常: " + e.message);
     }
 }
 

--- a/resources/QAU/qau_01.js
+++ b/resources/QAU/qau_01.js
@@ -239,7 +239,7 @@ function getCourseConfig() {
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("正在获取课表数据，请稍候...");
+        window.shiguangBridge.showToast("正在获取课表数据，请稍候...");
 
         const response = await fetch('/jsxsd/xskb/xskb_list.do', { method: 'GET' });
         const htmlText = await response.text();
@@ -265,19 +265,19 @@ async function runImportFlow() {
 
         // 选择学期
         if (semesters.length > 0) {
-            let selectedIdx = await window.AndroidBridgePromise.showSingleSelection(
+            let selectedIdx = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期",
                 JSON.stringify(semesters),
                 defaultIndex
             );
 
             if (selectedIdx === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
 
             if (selectedIdx !== defaultIndex) {
-                AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
+                window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
                 let formData = new URLSearchParams();
                 formData.append('xnxq01id', semesterValues[selectedIdx]);
 
@@ -293,14 +293,14 @@ async function runImportFlow() {
 
         // 选择校区
         const campusNames = Object.keys(CAMPUS_TIME_SLOTS);
-        const campusIdx = await window.AndroidBridgePromise.showSingleSelection(
+        const campusIdx = await window.shiguangBridgePromise.showSingleSelection(
             "请选择您所在的校区",
             JSON.stringify(campusNames),
             0
         );
 
         if (campusIdx === null) {
-            AndroidBridge.showToast("已取消导入");
+            window.shiguangBridge.showToast("已取消导入");
             return;
         }
 
@@ -311,7 +311,7 @@ async function runImportFlow() {
         const courses = extractCoursesFromDoc(doc);
 
         if (courses.length === 0) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "提示",
                 "未能解析到任何课程，请检查当前学期是否有排课，或尝试切换学期。",
                 "好的"
@@ -320,20 +320,20 @@ async function runImportFlow() {
         }
 
         // 保存
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(getCourseConfig()));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(getCourseConfig()));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!saveResult) {
-            AndroidBridge.showToast("课程保存失败，请重试！");
+            window.shiguangBridge.showToast("课程保存失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 节课程（${selectedCampus}作息）！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 节课程（${selectedCampus}作息）！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        AndroidBridge.showToast("导入发生异常: " + error.message);
+        window.shiguangBridge.showToast("导入发生异常: " + error.message);
     }
 }
 

--- a/resources/QQHRIT/qqhrit.js
+++ b/resources/QQHRIT/qqhrit.js
@@ -218,7 +218,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -228,7 +228,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -239,7 +239,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         -1
@@ -294,19 +294,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         console.error(`Request failed: ${targetUrl}`, e);
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -332,17 +332,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -352,14 +352,14 @@ async function runImportFlow() {
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -368,7 +368,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -388,10 +388,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -399,9 +399,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/QQHRU/qqhru.js
+++ b/resources/QQHRU/qqhru.js
@@ -29,7 +29,7 @@ function formatTime(timeStr) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -40,7 +40,7 @@ async function promptUserToStart() {
  * 获取学年
  */
 async function getAcademicYear() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "学年设置",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         "", 
@@ -53,7 +53,7 @@ async function getAcademicYear() {
  */
 async function selectSemester() {
     const semesters = ["1（第一学期）", "2（第二学期）"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", 
         JSON.stringify(semesters),
         -1 
@@ -85,7 +85,7 @@ async function fetchValidApiUrl() {
  */
 async function fetchAndParseJwData(academicYear, semesterIndex) {
     try {
-        AndroidBridge.showToast("正在获取教务初始化凭证...");
+        window.shiguangBridge.showToast("正在获取教务初始化凭证...");
         const targetApiSubUrl = await fetchValidApiUrl();
         if (!targetApiSubUrl) {
             throw new Error("初始化凭证获取失败，请确认是否处于登录状态");
@@ -95,7 +95,7 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
         const endYear = parseInt(academicYear) + 1;
         const planCode = `${academicYear}-${endYear}-${semesterValue}-1`;
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         const fullApiUrl = `https://172-20-139-153-7700.webvpn.qqhru.edu.cn${targetApiSubUrl}`;
         const response = await fetch(fullApiUrl, {
             "headers": { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" },
@@ -148,7 +148,7 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
 
         return { courses, timeSlots };
     } catch (e) {
-        AndroidBridge.showToast("同步失败: " + e.message);
+        window.shiguangBridge.showToast("同步失败: " + e.message);
         return null;
     }
 }
@@ -157,14 +157,14 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
  * 保存数据到应用
  */
 async function saveToApp(result) {
-    const courseSuccess = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
+    const courseSuccess = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
     if (!courseSuccess) return false;
 
     if (result.timeSlots && result.timeSlots.length > 0) {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
     }
     
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         semesterTotalWeeks: 20 
     }));
     
@@ -182,14 +182,14 @@ async function runImportFlow() {
     // 获取学年
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
     // 获取学期
     const semesterIndex = await selectSemester();
     if (semesterIndex === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
@@ -199,8 +199,8 @@ async function runImportFlow() {
 
     // 保存并结束
     if (await saveToApp(result)) {
-        AndroidBridge.showToast(`成功导入 ${result.courses.length} 个课程时段`);
-        AndroidBridge.notifyTaskCompletion(); 
+        window.shiguangBridge.showToast(`成功导入 ${result.courses.length} 个课程时段`);
+        window.shiguangBridge.notifyTaskCompletion(); 
     }
 }
 

--- a/resources/QUT/qut.js
+++ b/resources/QUT/qut.js
@@ -152,7 +152,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "青岛理工大学课表导入",
         "将从正方教务系统导入课程表。\n请确保已在教务系统中登录。",
         "开始导入"
@@ -162,7 +162,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     var currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2026-2027 应输入2026）:",
         currentYear,
@@ -173,7 +173,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     var semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    var semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    var semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -189,7 +189,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据。
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在获取课表数据...");
+    window.shiguangBridge.showToast("正在获取课表数据...");
 
     var semesterCode = getSemesterCode(semesterIndex);
     var requestBody = "xnm=" + encodeURIComponent(academicYear) +
@@ -225,19 +225,19 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         if (jsonText.indexOf("登录") !== -1 && jsonText.indexOf("密码") !== -1) {
-            AndroidBridge.showToast("未登录或登录已过期，请先登录教务系统");
+            window.shiguangBridge.showToast("未登录或登录已过期，请先登录教务系统");
             return null;
         }
 
         var courses = parseJsonData(jsonData);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
             return null;
         }
 
@@ -248,21 +248,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config };
 
     } catch (error) {
-        AndroidBridge.showToast("请求或解析失败: " + error.message);
+        window.shiguangBridge.showToast("请求或解析失败: " + error.message);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
+    window.shiguangBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
     console.log("JS: 尝试保存 " + parsedCourses.length + " 门课程...");
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("课程保存失败: " + error.message);
+        window.shiguangBridge.showToast("课程保存失败: " + error.message);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -286,40 +286,40 @@ async function importPresetTimeSlots(timeSlots) {
     console.log("JS: 准备导入 " + timeSlots.length + " 个预设时间段。");
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
+        window.shiguangBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
-    AndroidBridge.showToast("拾光课程表 - 青岛理工大学适配");
+    window.shiguangBridge.showToast("拾光课程表 - 青岛理工大学适配");
 
     var alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     var academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -327,7 +327,7 @@ async function runImportFlow() {
 
     var semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -348,18 +348,18 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
     } catch (error) {
-        AndroidBridge.showToast("课表配置保存失败: " + error.message);
+        window.shiguangBridge.showToast("课表配置保存失败: " + error.message);
         console.error('JS: Save Config Error:', error);
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast("成功导入 " + courses.length + " 门课程！");
+    window.shiguangBridge.showToast("成功导入 " + courses.length + " 门课程！");
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/SCUEC/scuec.js
+++ b/resources/SCUEC/scuec.js
@@ -486,7 +486,7 @@ async function showConfirmDialog(courseCount) {
     console.log('[步骤2] 显示确认弹窗...');
     
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "导入课程表",
             `检测到 ${courseCount} 门课程，是否导入？`,
             "确认导入"
@@ -512,19 +512,19 @@ async function saveCourses(courses) {
     console.log('[步骤3] 开始保存课程数据...');
     
     try {
-        AndroidBridge.showToast('正在保存课程...');
+        window.shiguangBridge.showToast('正在保存课程...');
         
-        const result = await window.AndroidBridgePromise.saveImportedCourses(
+        const result = await window.shiguangBridgePromise.saveImportedCourses(
             JSON.stringify(courses)
         );
         
         if (result === true) {
             console.log(`[步骤3] ✓ 成功保存 ${courses.length} 门课程\n`);
-            AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
             return true;
         } else {
             console.error('[步骤3] ✗ 课程保存失败');
-            AndroidBridge.showToast('课程保存失败');
+            window.shiguangBridge.showToast('课程保存失败');
             throw new Error('课程保存失败');
         }
     } catch (error) {
@@ -540,21 +540,21 @@ async function saveTimeSlots() {
     console.log('[步骤4] 开始保存时间段配置...');
     
     try {
-        AndroidBridge.showToast('正在保存时间段配置...');
+        window.shiguangBridge.showToast('正在保存时间段配置...');
         
         const timeSlots = generateTimeSlots();
         
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(
             JSON.stringify(timeSlots)
         );
         
         if (result === true) {
             console.log('[步骤4] ✓ 时间段配置保存成功\n');
-            AndroidBridge.showToast('时间段配置成功！');
+            window.shiguangBridge.showToast('时间段配置成功！');
             return true;
         } else {
             console.error('[步骤4] ✗ 时间段配置保存失败');
-            AndroidBridge.showToast('时间段配置失败');
+            window.shiguangBridge.showToast('时间段配置失败');
             throw new Error('时间段配置失败');
         }
     } catch (error) {
@@ -576,7 +576,7 @@ async function runImportFlow() {
     try {
         const courses = await fetchCoursesFromPage();
         if (!courses) {
-            AndroidBridge.showToast('未找到课程数据');
+            window.shiguangBridge.showToast('未找到课程数据');
             console.log('❌ 流程终止: 无课程数据\n');
             return false;
         }
@@ -600,8 +600,8 @@ async function runImportFlow() {
         }
         
         console.log('[步骤5] 发送完成信号...');
-        AndroidBridge.notifyTaskCompletion();
-        AndroidBridge.showToast('课程表导入完成！');
+        window.shiguangBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast('课程表导入完成！');
         
         console.log('\n╔════════════════════════════════════════╗');
         console.log('║    导入流程完成 ✓                     ║');
@@ -611,7 +611,7 @@ async function runImportFlow() {
     } catch (error) {
         console.error('\n❌ 导入流程出错:', error);
         console.log('╚════════════════════════════════════════╝\n');
-        AndroidBridge.showToast('导入失败: ' + error.message);
+        window.shiguangBridge.showToast('导入失败: ' + error.message);
         return false;
     }
 }
@@ -627,5 +627,5 @@ if (isOnSchedulePage() || document.querySelector('table.CourseFormTable')) {
     
 } else {
     console.log('✗ 当前不在课程表页面');
-    AndroidBridge.showToast('请先在教务系统打开课程表页面！');
+    window.shiguangBridge.showToast('请先在教务系统打开课程表页面！');
 }

--- a/resources/SCUT/SCUT_01.js
+++ b/resources/SCUT/SCUT_01.js
@@ -85,8 +85,8 @@ function extractOptionsByRegex(html, selectId) {
  */
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在通过 WebVPN 通道读取数据...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在通过 WebVPN 通道读取数据...");
         } else {
             console.log("【1/4】正在获取学期选项...");
         }
@@ -121,14 +121,14 @@ async function runImportFlow() {
 
         // 2. 弹出选择框
         let selectedIdx = defaultIndex;
-        if (typeof window.AndroidBridgePromise !== 'undefined') {
-            let userChoice = await window.AndroidBridgePromise.showSingleSelection(
+        if (typeof window.shiguangBridgePromise !== 'undefined') {
+            let userChoice = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期", 
                 JSON.stringify(semesters), 
                 defaultIndex
             );
             if (userChoice === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
             selectedIdx = userChoice;
@@ -148,8 +148,8 @@ async function runImportFlow() {
         }
 
         const targetData = semesterValues[selectedIdx];
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 数据...`);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 数据...`);
         } else {
             console.log(`【2/4】正在向服务器请求 [${semesters[selectedIdx]}] 的 JSON 数据...`);
         }
@@ -207,8 +207,8 @@ async function runImportFlow() {
 
         if (parsedCourses.length === 0) {
             const errMsg = "该学期暂无排课数据。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else alert(errMsg);
             return;
         }
@@ -230,30 +230,30 @@ async function runImportFlow() {
         };
 
         // 7. 打印并保存
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【测试成功】被 21:35 规则过滤后的作息时间表：\n", timeSlots);
             console.log(`【测试成功】共获取到 ${uniqueCourses.length} 门课程：\n`, JSON.stringify(uniqueCourses, null, 2));
             alert(`解析成功！获取到 ${uniqueCourses.length} 门课程及过滤后的作息时间。\n请打开F12控制台查看。`);
             return;
         }
 
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
         if (timeSlots.length > 0) {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         }
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(uniqueCourses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(uniqueCourses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存失败，请重试！");
+            window.shiguangBridge.showToast("保存失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${uniqueCourses.length} 节课程！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${uniqueCourses.length} 节课程！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("导入异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("导入异常: " + error.message);
         } else {
             console.error("【导入异常】", error);
             alert("导入异常: " + error.message);

--- a/resources/SDDFVC/sddfvc.js
+++ b/resources/SDDFVC/sddfvc.js
@@ -85,7 +85,7 @@ async function saveAppConfig() {
         "defaultBreakDuration": 15,
         "firstDayOfWeek": 1
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -100,7 +100,7 @@ async function saveAppTimeSlots() {
         { "number": 5, "startTime": "19:00", "endTime": "19:30" },
         { "number": 6, "startTime": "20:00", "endTime": "20:45" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -115,7 +115,7 @@ async function getSelectedSemesterId(apiToken) {
     const xqNames = xqList.map(item => item.xqmc);
     const defaultIdx = xqList.findIndex(item => item.id === currentXq.id);
 
-    const selectedIdx = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIdx = await window.shiguangBridgePromise.showSingleSelection(
         "请确认导入学期",
         JSON.stringify(xqNames),
         defaultIdx !== -1 ? defaultIdx : xqNames.length - 1
@@ -156,7 +156,7 @@ async function fetchFullSemesterData(apiToken, semesterId) {
     const totalWeeks = 22;
 
     for (let w = 1; w <= totalWeeks; w++) {
-        AndroidBridge.showToast(`正在获取第 ${w}/${totalWeeks} 周...`);
+        window.shiguangBridge.showToast(`正在获取第 ${w}/${totalWeeks} 周...`);
         try {
             const res = await fetch(`http://jwxt.sddfvc.edu.cn/mobile/student/mobile_kcb?api_token=${apiToken}&xq=${semesterId}&week=${w}`);
             const json = await res.json();
@@ -181,35 +181,35 @@ async function runImportFlow() {
         const apiToken = urlParams.get('api_token');
         if (!apiToken) {
             console.error("当前 URL 中未找到 api_token 参数:", window.location.href);
-            AndroidBridge.showToast("未检测到登录 Token，请确保在课表页面运行");
+            window.shiguangBridge.showToast("未检测到登录 Token，请确保在课表页面运行");
             return;
         }
         const semesterId = await getSelectedSemesterId(apiToken);
         if (!semesterId) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
         // 直接进入周遍历模式
-        AndroidBridge.showToast("开始抓取周课表数据...");
+        window.shiguangBridge.showToast("开始抓取周课表数据...");
         const finalCourses = await fetchFullSemesterData(apiToken, semesterId);
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现任何课程数据");
+            window.shiguangBridge.showToast("未发现任何课程数据");
             return;
         }
 
         // 保存逻辑
-        AndroidBridge.showToast("正在保存配置...");
+        window.shiguangBridge.showToast("正在保存配置...");
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/SDIPCT/sdipct.js
+++ b/resources/SDIPCT/sdipct.js
@@ -92,7 +92,7 @@ function validateYearInput(input) {
  * 步骤 A: 显示引导公告
  */
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务导入说明",
         "1. 请确保已在浏览器中成功登录教务系统\n2. 导入过程中请勿关闭页面",
         "好的，开始导入"
@@ -104,7 +104,7 @@ async function promptUserToStart() {
  */
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -117,7 +117,7 @@ async function getAcademicYear() {
  */
 async function selectSemester() {
     const semesters = ["第一学期 (秋季)", "第二学期 (春季)"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -129,7 +129,7 @@ async function selectSemester() {
  * 发起网络请求并获取数据
  */
 async function fetchCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求教务数据...");
+    window.shiguangBridge.showToast("正在请求教务数据...");
     
     const semesterCode = semesterIndex === 0 ? "01" : "02"; 
     const body = `xnxqdm=${academicYear}${semesterCode}`;
@@ -149,7 +149,7 @@ async function fetchCourses(academicYear, semesterIndex) {
         return parseJsonData(jsonData);
     } catch (e) {
         console.error("Fetch Error:", e);
-        AndroidBridge.showToast("网络请求失败，请检查登录状态");
+        window.shiguangBridge.showToast("网络请求失败，请检查登录状态");
         return null;
     }
 }
@@ -179,38 +179,38 @@ async function runImportFlow() {
     // 2. 获取参数（学年、学期）
     const year = await getAcademicYear();
     if (!year) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
     const semesterIdx = await selectSemester();
     if (semesterIdx === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
     // 3. 执行获取与解析
     const courses = await fetchCourses(year, semesterIdx);
     if (!courses || courses.length === 0) {
-        if (courses && courses.length === 0) AndroidBridge.showToast("该学期暂无课程数据");
+        if (courses && courses.length === 0) window.shiguangBridge.showToast("该学期暂无课程数据");
         return;
     }
 
     // 4. 数据保存
     try {
         // 保存课程
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         
         // 保存预设时间表
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(StandardTimeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(StandardTimeSlots));
         
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
         
         // 5. 流程收尾：通知原生端任务完成
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
         console.log("JS: 流程成功完成");
     } catch (e) {
-        AndroidBridge.showToast("保存失败: " + e.message);
+        window.shiguangBridge.showToast("保存失败: " + e.message);
     }
 }
 

--- a/resources/SDJTU/sdjtu.js
+++ b/resources/SDJTU/sdjtu.js
@@ -268,7 +268,7 @@ function getDefaultStartDate(semesterId) {
  */
 async function getSemesterStartDate(semesterId) {
     const defaultDate = getDefaultStartDate(semesterId);
-    const dateInput = await window.AndroidBridgePromise.showPrompt(
+    const dateInput = await window.shiguangBridgePromise.showPrompt(
         "设置开学日期",
         "请输入本学期开学日期，一般为周一（格式 YYYY-MM-DD，如 2026-02-23）：",
         defaultDate,
@@ -283,7 +283,7 @@ async function getSemesterStartDate(semesterId) {
 async function runImportFlow() {
     try {
         // 1. 确认提示
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "导入提示",
             "请确保您已登录教务系统并打开了【学期理论课表】页面（已选好学期）。\n脚本将直接读取当前页面的课表数据。",
             "确认并开始"
@@ -293,7 +293,7 @@ async function runImportFlow() {
         // 2. 获取课表文档
         const doc = getScheduleDocument();
         if (!doc) {
-            AndroidBridge.showToast("未找到课表页面，请先打开【学期理论课表】");
+            window.shiguangBridge.showToast("未找到课表页面，请先打开【学期理论课表】");
             return;
         }
 
@@ -302,14 +302,14 @@ async function runImportFlow() {
         // 3. 获取开学日期
         const startDate = await getSemesterStartDate(semesterId);
         if (startDate === null) {
-            AndroidBridge.showToast("已取消开学日期输入");
+            window.shiguangBridge.showToast("已取消开学日期输入");
             return;
         }
 
         // 4. 解析课程数据
         const courses = parseCourses(doc);
         if (courses.length === 0) {
-            AndroidBridge.showToast("未获取到课程数据，该学期可能暂无课表");
+            window.shiguangBridge.showToast("未获取到课程数据，该学期可能暂无课表");
             return;
         }
 
@@ -318,10 +318,10 @@ async function runImportFlow() {
 
         // 6. 保存数据
         if (timeSlots.length > 0) {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         }
 
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
         // 7. 保存课表配置（含开学日期）
         const config = {
@@ -331,14 +331,14 @@ async function runImportFlow() {
             defaultBreakDuration: 5,
             firstDayOfWeek: 1
         };
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 
-        AndroidBridge.showToast(`[${semesterId}] 成功导入 ${courses.length} 条课程记录！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`[${semesterId}] 成功导入 ${courses.length} 条课程记录！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error("适配脚本异常:", error);
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/SDLIVC/sdlivc.js
+++ b/resources/SDLIVC/sdlivc.js
@@ -14,8 +14,8 @@
     };
 
     function showToast(message) {
-        if (window.AndroidBridge && typeof window.AndroidBridge.showToast === 'function') {
-            window.AndroidBridge.showToast(message);
+        if (window.shiguangBridge && typeof window.shiguangBridge.showToast === 'function') {
+            window.shiguangBridge.showToast(message);
         } else {
             console.log('[Toast]', message);
         }
@@ -191,13 +191,13 @@
     }
 
     async function saveImportedData(courses) {
-        const courseResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const courseResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (courseResult !== true) {
             throw new Error('课程保存失败：' + courseResult);
         }
 
-        if (typeof window.AndroidBridgePromise.saveCourseConfig === 'function') {
-            const configResult = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+        if (typeof window.shiguangBridgePromise.saveCourseConfig === 'function') {
+            const configResult = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
                 semesterTotalWeeks: getMaxWeek(courses),
                 defaultClassDuration: 45,
                 defaultBreakDuration: 10,
@@ -210,11 +210,11 @@
     }
 
     async function promptUserToStart() {
-        if (!window.AndroidBridgePromise || typeof window.AndroidBridgePromise.showAlert !== 'function') {
+        if (!window.shiguangBridgePromise || typeof window.shiguangBridgePromise.showAlert !== 'function') {
             return true;
         }
 
-        return await window.AndroidBridgePromise.showAlert(
+        return await window.shiguangBridgePromise.showAlert(
             '山东轻工职业学院课表导入',
             '请确认已登录并进入“学期课表”页面。脚本将读取当前学期课表并导入拾光课程表。',
             '开始导入'
@@ -237,7 +237,7 @@
 
             await saveImportedData(courses);
             showToast('成功导入 ' + courses.length + ' 条课程');
-            window.AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.notifyTaskCompletion();
         } catch (error) {
             console.error('山东轻工职业学院课表导入失败', error);
             showToast('课表导入失败：' + error.message);

--- a/resources/SDNU/sdnu.js
+++ b/resources/SDNU/sdnu.js
@@ -136,7 +136,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -146,7 +146,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（如2025-2026 应该填2025）:",
         currentYear,
@@ -157,7 +157,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -178,7 +178,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -213,14 +213,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -236,21 +236,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -276,17 +276,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -294,21 +294,21 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -317,7 +317,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -337,10 +337,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -348,9 +348,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/SHUFEZJ/shufezj.js
+++ b/resources/SHUFEZJ/shufezj.js
@@ -135,7 +135,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "上海财经大学浙江学院 · 教务导入",
         "请先确保已在当前页面成功登录教务系统（CAS 统一身份认证）。\n\n导入时会自动识别页面上当前选中的学年和学期，无需手动选择。",
         "我已登录，开始导入"
@@ -144,7 +144,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 学年请输入 2025）:",
         currentYear,
@@ -154,7 +154,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第 1 学期", "第 2 学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -251,7 +251,7 @@ async function fetchAndParseCourses(xnm, xqmCandidates) {
 
         for (const url of targetUrls) {
             try {
-                AndroidBridge.showToast("正在获取课表数据，请稍候...");
+                window.shiguangBridge.showToast("正在获取课表数据，请稍候...");
                 const response = await fetch(url, {
                     method: "POST",
                     headers: {
@@ -284,17 +284,17 @@ async function fetchAndParseCourses(xnm, xqmCandidates) {
         }
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查登录状态或网络环境。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查登录状态或网络环境。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         return false;
     }
 }
@@ -318,12 +318,12 @@ const TimeSlots = [
 
 async function importPresetTimeSlots(timeSlots) {
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         }
     }
 }
@@ -331,7 +331,7 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
@@ -345,18 +345,18 @@ async function runImportFlow() {
         xqmCandidates = [autoSemester.xqm];
         const alt = { "3": "1", "1": "3", "12": "2", "2": "12" };
         if (alt[autoSemester.xqm]) xqmCandidates.push(alt[autoSemester.xqm]);
-        AndroidBridge.showToast(`已自动识别学年学期 ${xnm} / ${autoSemester.xqm}，开始获取课表...`);
+        window.shiguangBridge.showToast(`已自动识别学年学期 ${xnm} / ${autoSemester.xqm}，开始获取课表...`);
         console.log(`JS: 自动识别学年学期 xnm=${xnm}, xqm=${autoSemester.xqm}`);
     } else {
         const academicYear = await getAcademicYear();
         if (academicYear === null) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
 
         const semesterIndex = await selectSemester();
         if (semesterIndex === null || semesterIndex === -1) {
-            AndroidBridge.showToast("导入已取消。");
+            window.shiguangBridge.showToast("导入已取消。");
             return;
         }
         xnm = academicYear;
@@ -375,16 +375,16 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
         console.error('JS: Save Config Error:', error);
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/SHZQ/shzq.js
+++ b/resources/SHZQ/shzq.js
@@ -20,7 +20,7 @@ function validateYearInput(input) {
  */
 async function demoAlert() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "公告",
             "欢迎使用教务导入",
             "开始"
@@ -128,22 +128,22 @@ function isLoginPage() {
 async function getYearAndSemester() {
     try {
         let currentYear = new Date().getFullYear();
-        const yearSelection = await AndroidBridgePromise.showPrompt(
+        const yearSelection = await window.shiguangBridgePromise.showPrompt(
             "选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
             String(currentYear), "validateYearInput"
         );
         if (yearSelection === null) {
-            AndroidBridge.showToast("导入取消：未选择学年。");
+            window.shiguangBridge.showToast("导入取消：未选择学年。");
             return null;
         }
         const xnm = yearSelection;
 
         const semesters = ["1（第一学期）", "2（第二学期）"];
-        const semesterIndex = await AndroidBridgePromise.showSingleSelection(
+        const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
             "选择学期", JSON.stringify(semesters), -1
         );
         if (semesterIndex === null || semesterIndex === -1) {
-            AndroidBridge.showToast("导入取消：未选择学期。");
+            window.shiguangBridge.showToast("导入取消：未选择学期。");
             return null;
         }
         const xqmMapping = { 0: "3", 1: "12" };
@@ -152,7 +152,7 @@ async function getYearAndSemester() {
         return { xnm, xqm };
     } catch (error) {
         console.error("JS: 获取学年学期时出错:", error);
-        AndroidBridge.showToast("获取学年学期失败：" + error.message);
+        window.shiguangBridge.showToast("获取学年学期失败：" + error.message);
         return null;
     }
 }
@@ -165,7 +165,7 @@ async function getYearAndSemester() {
  */
 async function fetchCourses(xnm, xqm) {
     try {
-        AndroidBridge.showToast(`正在获取学期课程...`);
+        window.shiguangBridge.showToast(`正在获取学期课程...`);
         const requestBody = `xnm=${xnm}&xqm=${xqm}&kzlx=ck&xsdm=`;
         const response = await fetch("https://jw.shzq.edu.cn/jwglxt/kbcx/xskbcx_cxXsgrkb.html?gnmkdm=N2151", {
             method: "POST",
@@ -181,13 +181,13 @@ async function fetchCourses(xnm, xqm) {
         const data = await response.json();
         const courses = parseShzqCourseData(data);
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查学年学期或登录状态。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查学年学期或登录状态。");
             return null;
         }
         return courses;
     } catch (error) {
         console.error("JS: 获取课程数据时出错:", error);
-        AndroidBridge.showToast(`获取课程失败: ${error.message || error}`);
+        window.shiguangBridge.showToast(`获取课程失败: ${error.message || error}`);
         return null;
     }
 }
@@ -199,12 +199,12 @@ async function fetchCourses(xnm, xqm) {
  */
 async function saveCourses(courses) {
     try {
-        await AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2));
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2));
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
         return true;
     } catch (error) {
         console.error("JS: 保存课程时出错:", error);
-        AndroidBridge.showToast(`保存失败: ${error.message || error}`);
+        window.shiguangBridge.showToast(`保存失败: ${error.message || error}`);
         return false;
     }
 }
@@ -228,17 +228,17 @@ async function importPresetTimeSlots() {
 
     try {
         console.log("正在尝试导入预设时间段...");
-        const result = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        const result = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         if (result === true) {
             console.log("预设时间段导入成功！");
-            window.AndroidBridge.showToast("测试时间段导入成功！");
+            window.shiguangBridge.showToast("测试时间段导入成功！");
         } else {
             console.log("预设时间段导入未成功，结果：" + result);
-            window.AndroidBridge.showToast("测试时间段导入失败，请查看日志。");
+            window.shiguangBridge.showToast("测试时间段导入失败，请查看日志。");
         }
     } catch (error) {
         console.error("导入时间段时发生错误:", error);
-        window.AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
     }
 }
 /**
@@ -246,7 +246,7 @@ async function importPresetTimeSlots() {
  */
 async function runImportShzqCourses() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("检测到当前在登录页面，终止导入。");
         return;
     }
@@ -284,7 +284,7 @@ async function runImportShzqCourses() {
     console.log("JS: 所有导入步骤完成。");
 
     // 发送最终的生命周期完成信号
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/SICNU/school.js
+++ b/resources/SICNU/school.js
@@ -315,7 +315,7 @@ async function main() {
         console.log('[教务适配] 学期日期:', semesterInfo.startDate, '~', semesterInfo.endDate);
 
         // 2. 获取课程数据
-        AndroidBridge.showToast('正在采集课程数据...');
+        window.shiguangBridge.showToast('正在采集课程数据...');
         const data = await fetchCourseData(semesterInfo.id);
 
         if (!data || !data.lessons || data.lessons.length === 0) {
@@ -373,32 +373,32 @@ async function main() {
         console.log('  - 开学日期:', config.semesterStartDate);
 
         // 7. 导入数据
-        AndroidBridge.showToast(`正在导入 ${allCourses.length} 门课程...`);
+        window.shiguangBridge.showToast(`正在导入 ${allCourses.length} 门课程...`);
 
-        const courseResult = await window.AndroidBridgePromise.saveImportedCourses(
+        const courseResult = await window.shiguangBridgePromise.saveImportedCourses(
             JSON.stringify(allCourses)
         );
         console.log('[教务适配] 课程导入结果:', courseResult);
 
-        const timeSlotResult = await window.AndroidBridgePromise.savePresetTimeSlots(
+        const timeSlotResult = await window.shiguangBridgePromise.savePresetTimeSlots(
             JSON.stringify(timeSlots)
         );
         console.log('[教务适配] 时间段导入结果:', timeSlotResult);
 
-        const configResult = await window.AndroidBridgePromise.saveCourseConfig(
+        const configResult = await window.shiguangBridgePromise.saveCourseConfig(
             JSON.stringify(config)
         );
         console.log('[教务适配] 配置导入结果:', configResult);
 
         // 8. 触发下载
         console.log('[教务适配] ✅ 所有数据导入完成，触发下载...');
-        AndroidBridge.showToast('课程数据采集完成！请保存下载的文件。');
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast('课程数据采集完成！请保存下载的文件。');
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error('[教务适配] ❌ 执行失败:', error.message);
         console.error(error.stack);
-        AndroidBridge.showToast('采集失败: ' + error.message);
+        window.shiguangBridge.showToast('采集失败: ' + error.message);
     }
 }
 

--- a/resources/STCNCHU/stcnchu.js
+++ b/resources/STCNCHU/stcnchu.js
@@ -142,7 +142,7 @@ function parseTimetableToModel(doc) {
 
 async function saveAppConfig() {
     const config = { "semesterTotalWeeks": 20, "firstDayOfWeek": 1 };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -207,31 +207,31 @@ async function saveAppTimeSlots(campusIndex, semesterIndex) {
     const targetCampus = (campusIndex === 0) ? campus1_slots : campus2_slots;
     const selectedSlots = (semesterIndex === 0) ? targetCampus.winter : targetCampus.summer;
 
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(selectedSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(selectedSlots));
 }
 
 // ================= 流程编排 =================
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
+        const confirmed = await window.shiguangBridgePromise.showAlert("提示", "请确保已成功登录教务系统。是否开始导入？", "开始");
         if (!confirmed) return;
 
         // 1. 获取就读校区
-        const campusIndex = await window.AndroidBridgePromise.showSingleSelection("选择所在校区", JSON.stringify(["共青城校区", "上海路校区"]), -1);
+        const campusIndex = await window.shiguangBridgePromise.showSingleSelection("选择所在校区", JSON.stringify(["共青城校区", "上海路校区"]), -1);
         if (campusIndex === null) return;
 
         // 2. 获取学年
-        const year = await window.AndroidBridgePromise.showPrompt("选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", "", "validateYearInput");
+        const year = await window.shiguangBridgePromise.showPrompt("选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", "", "validateYearInput");
         if (!year) return;
 
         // 3. 获取学期并记录索引
-        const semesterIndex = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), -1);
+        const semesterIndex = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(["第一学期", "第二学期"]), -1);
         if (semesterIndex === null) return;
 
         const semesterId = `${year}-${parseInt(year) + 1}-${semesterIndex + 1}`;
 
-        AndroidBridge.showToast("正在请求数据...");
+        window.shiguangBridge.showToast("正在请求数据...");
         const response = await fetch("http://qzjwxt.stcnchu.edu.cn:800/jsxsd/xskb/xskb_list.do", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -243,7 +243,7 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程，请检查学期选择或登录状态。");
+            window.shiguangBridge.showToast("未发现课程，请检查学期选择或登录状态。");
             return;
         }
 
@@ -252,12 +252,12 @@ async function runImportFlow() {
         // 传入校区索引和学期索引联合控制作息映射
         await saveAppTimeSlots(campusIndex, semesterIndex);
         // 保存课程
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/SUDA/suda.js
+++ b/resources/SUDA/suda.js
@@ -195,35 +195,35 @@ function findScheduleTable() {
 
 async function runImportFlow() {
     // 1. 开始提示
-    const confirmed = await AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "苏大课表导入",
         "请确保当前页面已显示「学生个人课表」\n导入前请先在页面上选好学年和学期",
         "开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
     // 2. 查找课表
-    AndroidBridge.showToast("正在查找课表...");
+    window.shiguangBridge.showToast("正在查找课表...");
     const table = findScheduleTable();
     if (!table) {
-        AndroidBridge.showToast("未找到课表，请先打开「学生个人课表」页面。");
+        window.shiguangBridge.showToast("未找到课表，请先打开「学生个人课表」页面。");
         return;
     }
     // 3. 解析课程
-    AndroidBridge.showToast("正在解析课程数据...");
+    window.shiguangBridge.showToast("正在解析课程数据...");
     const courses = parseCourseTable(table);
     if (courses.length === 0) {
-        AndroidBridge.showToast("未解析到任何课程，请确认课表已正确加载。");
+        window.shiguangBridge.showToast("未解析到任何课程，请确认课表已正确加载。");
         return;
     }
     // 4. 保存课程
-    AndroidBridge.showToast(`正在保存 ${courses.length} 条课程...`);
-    await AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    window.shiguangBridge.showToast(`正在保存 ${courses.length} 条课程...`);
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
     // 5. 保存作息时间
-    AndroidBridge.showToast(`正在导入 ${TimeSlots.length} 个时间段...`);
-    await AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
+    window.shiguangBridge.showToast(`正在导入 ${TimeSlots.length} 个时间段...`);
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
     // 6. 保存配置（select 在课表同一文档中，用 ownerDocument 确保 iframe 场景正确）
     const semesterStartDate = detectSemesterStartDate(table.ownerDocument);
     const config = {
@@ -231,10 +231,10 @@ async function runImportFlow() {
         semesterTotalWeeks: 20,
         firstDayOfWeek: 1
     };
-    await AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     // 7. 完成
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 条课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 条课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/SWJTU/swjtu_vatuu.js
+++ b/resources/SWJTU/swjtu_vatuu.js
@@ -274,11 +274,11 @@
 
     async function importSwjtuSchedule() {
         try {
-            AndroidBridge.showToast("正在解析西南交通大学 VATUU 课表...");
+            window.shiguangBridge.showToast("正在解析西南交通大学 VATUU 课表...");
 
             const courses = await parseScheduleTable();
             if (courses.length === 0) {
-                await window.AndroidBridgePromise.showAlert(
+                await window.shiguangBridgePromise.showAlert(
                     "导入失败",
                     "未解析到课程。请确认当前页面为本学期课表，并选择“全部周次”。",
                     "确定",
@@ -286,30 +286,30 @@
                 return false;
             }
 
-            await window.AndroidBridgePromise.saveCourseConfig(
+            await window.shiguangBridgePromise.saveCourseConfig(
                 JSON.stringify(SWJTU_COURSE_CONFIG),
             );
-            await window.AndroidBridgePromise.savePresetTimeSlots(
+            await window.shiguangBridgePromise.savePresetTimeSlots(
                 JSON.stringify(SWJTU_TIME_SLOTS),
             );
-            await window.AndroidBridgePromise.saveImportedCourses(
+            await window.shiguangBridgePromise.saveImportedCourses(
                 JSON.stringify(courses),
             );
 
             const unscheduledCourses = collectUnscheduledCourses();
             if (unscheduledCourses.length > 0) {
-                AndroidBridge.showToast(
+                window.shiguangBridge.showToast(
                     `成功导入 ${courses.length} 条课程，另有 ${unscheduledCourses.length} 门无节次课程已跳过`,
                 );
             } else {
-                AndroidBridge.showToast(`成功导入 ${courses.length} 条课程`);
+                window.shiguangBridge.showToast(`成功导入 ${courses.length} 条课程`);
             }
 
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.notifyTaskCompletion();
             return true;
         } catch (error) {
             console.error("SWJTU VATUU 课表导入失败：", error);
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "导入失败",
                 `解析或保存课表失败：${error.message}`,
                 "确定",

--- a/resources/SXGCXY/sxgcxy_01.js
+++ b/resources/SXGCXY/sxgcxy_01.js
@@ -175,7 +175,7 @@ async function selectCampusTimeTable() {
     
     const defaultIndex = -1; 
     
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "请选择校区对应的作息时间",
         JSON.stringify(labels),
         defaultIndex 
@@ -224,7 +224,7 @@ async function selectAcademicYearAndSemester() {
     console.log("JS: 提示用户选择学年学期 (纯参数格式)。");
     const { labels, values, defaultIndex } = getSemesterOptions();
     
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学年学期 (参数格式：YYYY-YYYY-X)",
         JSON.stringify(labels),
         defaultIndex
@@ -248,7 +248,7 @@ function isLoginPage() {
 
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入 (超星)",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -260,7 +260,7 @@ async function promptUserToStart() {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(xnxq) {
-    AndroidBridge.showToast(`正在请求 ${xnxq} 的课表数据...`);
+    window.shiguangBridge.showToast(`正在请求 ${xnxq} 的课表数据...`);
 
     // xhid 需要从页面获取
     const xhid = document.getElementById('encodeId')?.value || 'UNKNOWN'; 
@@ -289,14 +289,14 @@ async function fetchAndParseCourses(xnxq) {
         
         if (jsonData.ret !== 0) {
              console.error(`JS: API 返回错误: ${jsonData.msg}`);
-             AndroidBridge.showToast(`数据请求失败: ${jsonData.msg}，请检查是否登录或参数是否正确。`);
+             window.shiguangBridge.showToast(`数据请求失败: ${jsonData.msg}，请检查是否登录或参数是否正确。`);
              return null;
         }
 
         const courses = parseJsonData(jsonData);    
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
             return null;
         }
 
@@ -304,19 +304,19 @@ async function fetchAndParseCourses(xnxq) {
         return { courses: courses };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         return false;
     }
 }
@@ -324,34 +324,34 @@ async function saveCourses(parsedCourses) {
 async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 导入预设时间段。`);
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
     }
 }
 
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
     
     const selectedTimeSlots = await selectCampusTimeTable();
     if (selectedTimeSlots === null) {
-        AndroidBridge.showToast("导入已取消，未选择作息时间。");
+        window.shiguangBridge.showToast("导入已取消，未选择作息时间。");
         return;
     }
     console.log(`JS: 已选择包含 ${selectedTimeSlots.length} 节课的作息时间。`);
@@ -359,7 +359,7 @@ async function runImportFlow() {
 
     const xnxq = await selectAcademicYearAndSemester();
     if (xnxq === null) {
-        AndroidBridge.showToast("导入已取消，未选择学年学期。");
+        window.shiguangBridge.showToast("导入已取消，未选择学年学期。");
         return;
     }
     console.log(`JS: 已选择学年学期参数: ${xnxq}`);
@@ -378,8 +378,8 @@ async function runImportFlow() {
     await importPresetTimeSlots(selectedTimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/TARU/taru_01.js
+++ b/resources/TARU/taru_01.js
@@ -136,7 +136,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -146,7 +146,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -157,7 +157,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -178,7 +178,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -211,14 +211,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -227,21 +227,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -275,7 +275,7 @@ const SummerTimeSlots = [
 async function selectTimeSlotsType() {
     const timeSlotsOptions = ["非夏季作息", "夏季作息"];
     console.log("JS: 提示用户选择作息时间类型。");
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(timeSlotsOptions),
         0
@@ -287,17 +287,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -305,7 +305,7 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
@@ -313,14 +313,14 @@ async function runImportFlow() {
     // 1. 公告和前置检查。
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -329,7 +329,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -369,9 +369,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(selectedTimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/TCU/tcu_01.js
+++ b/resources/TCU/tcu_01.js
@@ -29,7 +29,7 @@ function formatTime(timeStr) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -40,7 +40,7 @@ async function promptUserToStart() {
  * 获取学年
  */
 async function getAcademicYear() {
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "学年设置",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         "", 
@@ -53,7 +53,7 @@ async function getAcademicYear() {
  */
 async function selectSemester() {
     const semesters = ["1（第一学期）", "2（第二学期）"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", 
         JSON.stringify(semesters),
         -1 
@@ -69,7 +69,7 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
         const endYear = parseInt(academicYear) + 1;
         const planCode = `${academicYear}-${endYear}-${semesterValue}-1`;
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         const response = await fetch("https://jwxs.tcu.edu.cn/student/courseSelect/thisSemesterCurriculum/ajaxStudentSchedule/callback", {
             "headers": { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" },
             "body": `&planCode=${planCode}`,
@@ -123,7 +123,7 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
 
         return { courses, timeSlots };
     } catch (e) {
-        AndroidBridge.showToast("同步失败: " + e.message);
+        window.shiguangBridge.showToast("同步失败: " + e.message);
         return null;
     }
 }
@@ -132,12 +132,12 @@ async function fetchAndParseJwData(academicYear, semesterIndex) {
  * 保存数据到应用
  */
 async function saveToApp(result) {
-    const courseSuccess = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
+    const courseSuccess = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
     if (!courseSuccess) return false;
 
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
     
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         semesterTotalWeeks: 20 
     }));
     
@@ -155,14 +155,14 @@ async function runImportFlow() {
     // 获取学年
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
     // 获取学期
     const semesterIndex = await selectSemester();
     if (semesterIndex === null) {
-        AndroidBridge.showToast("导入已取消");
+        window.shiguangBridge.showToast("导入已取消");
         return;
     }
 
@@ -172,8 +172,8 @@ async function runImportFlow() {
 
     // 保存并结束
     if (await saveToApp(result)) {
-        AndroidBridge.showToast(`成功导入 ${result.courses.length} 个课程时段`);
-        AndroidBridge.notifyTaskCompletion(); 
+        window.shiguangBridge.showToast(`成功导入 ${result.courses.length} 个课程时段`);
+        window.shiguangBridge.notifyTaskCompletion(); 
     }
 }
 

--- a/resources/TJAU/tjau.js
+++ b/resources/TJAU/tjau.js
@@ -207,7 +207,7 @@ async function getSelectedSemester(tagId) {
     for (let key in data.semesters) {
         data.semesters[key].forEach(s => list.push({ id: s.id, name: `${s.schoolYear} ${s.name}学期` }));
     }
-    const idx = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(list.map(s => s.name)), 0);
+    const idx = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(list.map(s => s.name)), 0);
     return idx !== null ? list[idx] : null;
 }
 
@@ -234,34 +234,34 @@ async function applyTimeSlots() {
         { "number": 10, "startTime": "19:20", "endTime": "20:05" },
         { "number": 11, "startTime": "20:10", "endTime": "20:55" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(slots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(slots));
 }
 
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("开始探测教务参数...");
+        window.shiguangBridge.showToast("开始探测教务参数...");
         const params = await detectParameters();
         if (!params) throw new Error("未能识别教务参数，请确认已登录");
 
         const semester = await getSelectedSemester(params.tagId);
         if (!semester) return; 
 
-        AndroidBridge.showToast("正在同步课表...");
+        window.shiguangBridge.showToast("正在同步课表...");
         const courses = await fetchAndParseCourses(semester.id, params.ids);
         
         if (!courses || courses.length === 0) throw new Error("未解析到课程数据");
 
         await applyTimeSlots();
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         
         if (saveResult) {
-            AndroidBridge.showToast(`成功导入 ${courses.length} 个课程条目`);
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 个课程条目`);
+            window.shiguangBridge.notifyTaskCompletion();
         }
     } catch (e) {
         console.error(`[异常] ${e.message}`);
-        AndroidBridge.showToast(e.message);
+        window.shiguangBridge.showToast(e.message);
     }
 }
 

--- a/resources/TONGJI/tongji_01.js
+++ b/resources/TONGJI/tongji_01.js
@@ -45,7 +45,7 @@
       res.json(),
     );
     const currTermId = currTermResponse.data.schoolCalendar.id;
-    const useOtherTerm = await AndroidBridgePromise.showSingleSelection(
+    const useOtherTerm = await window.shiguangBridgePromise.showSingleSelection(
       "是否使用当前学期",
       JSON.stringify([
         `使用当前学期\n(${currTermResponse.data.simpleName})`,
@@ -54,19 +54,19 @@
     );
     let termId = currTermId;
     if (useOtherTerm === null)
-      AndroidBridge.showToast("未选择学期，使用当前学期");
+      window.shiguangBridge.showToast("未选择学期，使用当前学期");
     else if (useOtherTerm === 1) {
-      AndroidBridge.showToast("正在加载学期列表");
+      window.shiguangBridge.showToast("正在加载学期列表");
       const termListResponse = await fetch(ENDPOINTS.termList()).then((res) =>
         res.json(),
       );
-      const index = await AndroidBridgePromise.showSingleSelection(
+      const index = await window.shiguangBridgePromise.showSingleSelection(
         "请选择学期",
         JSON.stringify(termListResponse.data.map((term) => term.fullName)),
       );
       const selectedId = termListResponse.data[index]?.id;
       if (selectedId) termId = selectedId;
-      else AndroidBridge.showToast("未选择学期，使用当前学期");
+      else window.shiguangBridge.showToast("未选择学期，使用当前学期");
     }
     const termMetaDataResponse = await fetch(
       ENDPOINTS.termMetaData(termId),
@@ -103,9 +103,9 @@
       ...courseInfo.map((c) => Math.max(...c.weeks)),
     );
     const result = await Promise.allSettled([
-      AndroidBridgePromise.saveImportedCourses(JSON.stringify(courseInfo)),
-      AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots)),
-      AndroidBridgePromise.saveCourseConfig(
+      window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courseInfo)),
+      window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots)),
+      window.shiguangBridgePromise.saveCourseConfig(
         JSON.stringify({ semesterStartDate, semesterTotalWeeks }),
       ),
     ]);
@@ -118,10 +118,10 @@
 
   main()
     .catch((e) => {
-      AndroidBridge.showToast(`错误: ${e.message ?? e}`);
+      window.shiguangBridge.showToast(`错误: ${e.message ?? e}`);
       console.error(e);
     })
     .finally(() => {
-      AndroidBridge.notifyTaskCompletion();
+      window.shiguangBridge.notifyTaskCompletion();
     });
 })();

--- a/resources/TSU/tsu_01.js
+++ b/resources/TSU/tsu_01.js
@@ -168,24 +168,24 @@ async function fetchAndParseCourses() {
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("泰山学院引擎启动，抓取数据中...");
+        window.shiguangBridge.showToast("泰山学院引擎启动，抓取数据中...");
         const courses = await fetchAndParseCourses();
         if (!courses || courses.length === 0) {
-            AndroidBridge.showToast("解析完成，但当前课表为空");
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.showToast("解析完成，但当前课表为空");
+            window.shiguangBridge.notifyTaskCompletion();
             return;
         }
 
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (saveResult !== true) return;
 
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(SECTION_TIMES));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(SECTION_TIMES));
 
-        AndroidBridge.showToast(`导入大成功！合并生成 ${courses.length} 个课块`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`导入大成功！合并生成 ${courses.length} 个课块`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
-        AndroidBridge.showToast("⚠️ " + error.message);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("⚠️ " + error.message);
+        window.shiguangBridge.notifyTaskCompletion();
     }
 }
 

--- a/resources/UESTC/uestc.js
+++ b/resources/UESTC/uestc.js
@@ -431,7 +431,7 @@ async function runImportFlow() {
 
   try {
     // ── Step 1: 欢迎提示 ──
-    const ready = await window.AndroidBridgePromise.showAlert(
+    const ready = await window.shiguangBridgePromise.showAlert(
       '电子科技大学 - 教务导入',
       '请确保已在 eams.uestc.edu.cn 完成登录。\n\n建议先在教务中打开「个人课表」页面，\n然后返回本应用执行导入。',
       '已登录，开始导入'
@@ -443,7 +443,7 @@ async function runImportFlow() {
     const labels = options.map(o => o.label);
     const defaultIdx = Math.min(4, labels.length - 1);
 
-    const selectedIdx = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIdx = await window.shiguangBridgePromise.showSingleSelection(
       '选择学期',
       JSON.stringify(labels),
       defaultIdx
@@ -454,7 +454,7 @@ async function runImportFlow() {
     console.log(`📅 学期: ${options[selectedIdx].label} (id=${semesterId})`);
 
     // ── Step 3: 获取课表数据 ──
-    AndroidBridge.showToast('正在获取课表数据...');
+    window.shiguangBridge.showToast('正在获取课表数据...');
     const html = await fetchCourseHtml(semesterId);
 
     // ── Step 4: 解析 ──
@@ -463,8 +463,8 @@ async function runImportFlow() {
     console.log(`📊 活动记录: ${activities.length} 条`);
 
     if (activities.length === 0) {
-      AndroidBridge.showToast('未找到课程数据');
-      await window.AndroidBridgePromise.showAlert('导入结果', '未在当前学期找到课程数据。', '知道了');
+      window.shiguangBridge.showToast('未找到课程数据');
+      await window.shiguangBridgePromise.showAlert('导入结果', '未在当前学期找到课程数据。', '知道了');
       return;
     }
 
@@ -472,35 +472,35 @@ async function runImportFlow() {
     console.log(`📋 课程: ${courses.length} 门`);
 
     // ── Step 5: 保存 ──
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
     console.log('✅ 课程已保存');
 
     try {
-      await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(DEFAULT_TIME_SLOTS));
+      await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(DEFAULT_TIME_SLOTS));
       console.log('✅ 时间段已保存');
     } catch (e) { console.warn('⚠️ 时间段保存失败:', e.message); }
 
     try {
-      await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+      await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
         semesterTotalWeeks: UESTC_CONFIG.defaultTotalWeeks,
       }));
       console.log('✅ 配置已保存');
     } catch (e) { console.warn('⚠️ 配置保存失败:', e.message); }
 
     // ── Step 6: 完成 ──
-    AndroidBridge.showToast(`导入成功！共 ${courses.length} 门课程`);
-    await window.AndroidBridgePromise.showAlert(
+    window.shiguangBridge.showToast(`导入成功！共 ${courses.length} 门课程`);
+    await window.shiguangBridgePromise.showAlert(
       '✅ 导入完成',
       `成功导入 ${courses.length} 门课程。\n学期: ${options[selectedIdx].label}\n请返回课表查看。`,
       '好的'
     );
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 
   } catch (error) {
     console.error('❌ 导入失败:', error);
-    AndroidBridge.showToast('导入失败: ' + error.message);
+    window.shiguangBridge.showToast('导入失败: ' + error.message);
     try {
-      await window.AndroidBridgePromise.showAlert(
+      await window.shiguangBridgePromise.showAlert(
         '❌ 导入失败',
         '错误: ' + error.message + '\n\n请检查:\n1. 已登录 eams.uestc.edu.cn\n2. 网络正常\n3. 可先打开个人课表页面',
         '知道了'

--- a/resources/UJN/school.js
+++ b/resources/UJN/school.js
@@ -193,13 +193,13 @@ async function saveCourses() {
   });
 
   try {
-    await window.AndroidBridgePromise.saveImportedCourses(
+    await window.shiguangBridgePromise.saveImportedCourses(
       JSON.stringify(courseModels),
     );
     return courseModels.length;
   } catch (error) {
     console.error("保存课程失败:", error);
-    window.AndroidBridge.showToast("保存课程失败，请重试");
+    window.shiguangBridge.showToast("保存课程失败，请重试");
     return 0;
   }
 }
@@ -211,9 +211,9 @@ async function checkEnvirenment() {
     !nowSite.includes(urlPersonnalClassTable) &&
     !nowSite.includes(urlClassTable)
   ) {
-    window.AndroidBridge.showToast("当前页面不在支持的导入范围内");
+    window.shiguangBridge.showToast("当前页面不在支持的导入范围内");
     const selectedOption =
-      await window.AndroidBridgePromise.showSingleSelection(
+      await window.shiguangBridgePromise.showSingleSelection(
         "现在不在可导入的页面中，请选择导入班级课表还是个人课表，之后并确保打开具体课程页面",
         JSON.stringify(tableType), // 必须是 JSON 字符串
         -1, // 默认不选中
@@ -243,7 +243,7 @@ async function checkEnvirenment() {
 }
 
 async function runImportFlow() {
-  window.AndroidBridge.showToast("课程导入流程即将开始...");
+  window.shiguangBridge.showToast("课程导入流程即将开始...");
 
   if (!(await checkEnvirenment())) return;
 
@@ -265,17 +265,17 @@ async function runImportFlow() {
     new CustomTimeModel(11, "20:50", "21:45"),
   ];
   try {
-    await window.AndroidBridgePromise.savePresetTimeSlots(
+    await window.shiguangBridgePromise.savePresetTimeSlots(
       JSON.stringify(slots),
     );
   } catch (error) {
     console.error("保存时间段失败:", error);
-    window.AndroidBridge.showToast("保存时间段失败，请重试");
+    window.shiguangBridge.showToast("保存时间段失败，请重试");
     return;
   }
   // 8. 流程**完全成功**，发送结束信号。
-  AndroidBridge.showToast(`导入成功：共 ${savedCourseCount} 门课程`);
-  AndroidBridge.notifyTaskCompletion();
+  window.shiguangBridge.showToast(`导入成功：共 ${savedCourseCount} 门课程`);
+  window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动导入流程

--- a/resources/UJS/ujs_zhengfang_v9.0.js
+++ b/resources/UJS/ujs_zhengfang_v9.0.js
@@ -231,7 +231,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -244,7 +244,7 @@ async function getAcademicYear() {
     // 如果当前月份在8月或之后，默认学年是当前年份-下一年份，否则是上一年份-当前年份
     const defaultYear = currentMonth >= 8 ? currentYear : (Number(currentYear) - 1).toString(); 
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（如2025-2026 应该填2025）:",
         defaultYear,
@@ -257,7 +257,7 @@ async function selectSemester() {
     const currentMonth = new Date().getMonth() + 1; // 月份从0开始，所以加1
     const defaultSemesterIndex = currentMonth >= 8 ? 0 : 1; // 如果当前月份在8月或之后，默认选择第一学期，否则选择第二学期
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         defaultSemesterIndex
@@ -268,7 +268,7 @@ async function selectSemester() {
 async function selectTimeSlot() {
     const timeSlots = ["智能选择" ,"夏令时", "冬令时"];
     console.log("JS: 提示用户选择作息类型。");
-    const timeSlotIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const timeSlotIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(timeSlots),
         0
@@ -279,7 +279,7 @@ async function selectTimeSlot() {
 async function reselectTimeSlot(selectedTimeSlot) {
     const options = ["对的对的，就是这个", "不对不对，应该是另外一个"];
     const dialogTitle = "当前智能选择结果为: " + (selectedTimeSlot ? "夏令时" : "冬令时") + "，是否更改选择？";
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         dialogTitle,
         JSON.stringify(options),
         0
@@ -306,7 +306,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
 
@@ -338,14 +338,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -363,21 +363,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -558,17 +558,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -576,14 +576,14 @@ async function importPresetTimeSlots(timeSlots) {
 
 async function runImportFlow() {
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
@@ -594,7 +594,7 @@ async function runImportFlow() {
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -603,7 +603,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -611,7 +611,7 @@ async function runImportFlow() {
 
     const timeSlotIndex = await selectTimeSlot();
     if (timeSlotIndex === null || timeSlotIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择作息类型失败/取消，流程终止。");
         return;
     }
@@ -647,7 +647,7 @@ async function runImportFlow() {
     const coursesWithCustomTime = applyCustomTimeToCourses(courses, isSummerTime);
 
     // 只匹配了主A楼、京江楼、三江楼、三山楼、讲堂群这几个教学楼的作息时间，其他课程都使用默认时间
-    const timeSlotAlert = await window.AndroidBridgePromise.showAlert(
+    const timeSlotAlert = await window.shiguangBridgePromise.showAlert(
         "楼栋自定义时间提示",
         "脚本已根据课程所在位置智能匹配了作息时间，部分课程可能与预设时间不符。\n" +
         "请在课表页面核对课程时间，如有错误请手动修改课程所在位置或节次信息。\n" +
@@ -663,19 +663,19 @@ async function runImportFlow() {
     }
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
     await importPresetTimeSlots(isSummerTime ? SummerTimeSlots : WinterTimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${coursesWithCustomTime.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${coursesWithCustomTime.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/UPC/upc.js
+++ b/resources/UPC/upc.js
@@ -118,7 +118,7 @@ async function saveAppConfig() {
     const config = {
         "firstDayOfWeek": 7
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -139,7 +139,7 @@ async function saveAppTimeSlots() {
         { "number": 11, "startTime": "19:50", "endTime": "20:35" },
         { "number": 12, "startTime": "20:40", "endTime": "21:25" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -147,12 +147,12 @@ async function saveAppTimeSlots() {
  */
 async function getSelectedSemesterId() {
     const currentYear = new Date().getFullYear();
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年", "请输入起始学年（如 2025-2026 应输入 2025）:", String(currentYear), "validateYearInput"
     );
     if (!year) return null;
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", JSON.stringify(["第一学期", "第二学期"]), 0
     );
     if (semesterIndex === null) return null;
@@ -164,7 +164,7 @@ async function getSelectedSemesterId() {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "导入提示",
             "脚本将获取当前教务系统的课表数据。请确保您已登录。是否继续？",
             "确认并开始"
@@ -173,11 +173,11 @@ async function runImportFlow() {
 
         const semesterId = await getSelectedSemesterId();
         if (!semesterId) {
-            AndroidBridge.showToast("用户取消了学期选择");
+            window.shiguangBridge.showToast("用户取消了学期选择");
             return;
         }
 
-        AndroidBridge.showToast("正在请求教务数据...");
+        window.shiguangBridge.showToast("正在请求教务数据...");
         const response = await fetch("https://jwxt-443.webvpn.upc.edu.cn/jsxsd/xskb/xskb_list.do", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -191,20 +191,20 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现课程数据，请检查该学期是否有课或登录是否过期");
+            window.shiguangBridge.showToast("未发现课程数据，请检查该学期是否有课或登录是否过期");
             return;
         }
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程！`);
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程！`);
 
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
         console.error(error);
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/USTC/ustc.js
+++ b/resources/USTC/ustc.js
@@ -300,7 +300,7 @@ async function pollUntilTableReady(intervalMs, maxAttempts) {
  */
 async function runImportFlow() {
     // 步骤 1：提示用户
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "USTC 课表导入",
         "请确保您已登录教务系统(jw.ustc.edu.cn)并处于课表查询页面。\n\n" +
         "操作步骤：\n" +
@@ -314,7 +314,7 @@ async function runImportFlow() {
 
     // 步骤 2：检查当前页面是否为教务系统
     if (!window.location.href.startsWith("https://jw.ustc.edu.cn")) {
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "页面错误",
             "当前页面不是教务系统页面，请先登录并导航到「学生课表」页面。",
             "确定"
@@ -323,17 +323,17 @@ async function runImportFlow() {
     }
 
     // 步骤 3：轮询等待课表 DOM 加载完成（含 iframe 检测）
-    AndroidBridge.showToast("正在等待课表加载...");
+    window.shiguangBridge.showToast("正在等待课表加载...");
     var timetableDoc = await pollUntilTableReady();
     if (!timetableDoc) {
-        AndroidBridge.showToast("未找到课表，请确认已进入「学生课表」页面且课表已加载");
+        window.shiguangBridge.showToast("未找到课表，请确认已进入「学生课表」页面且课表已加载");
         return;
     }
 
     // 步骤 4：解析课程数据（表格已加载，可能为空学期）
     var courses = parseCoursesFromDoc(timetableDoc);
     if (courses.length === 0) {
-        AndroidBridge.showToast("该学期暂无课程数据");
+        window.shiguangBridge.showToast("该学期暂无课程数据");
         return;
     }
 
@@ -342,27 +342,27 @@ async function runImportFlow() {
 
     // 步骤 6：保存时间段
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(
+        await window.shiguangBridgePromise.savePresetTimeSlots(
             JSON.stringify(getUSTCTimeSlots())
         );
     } catch (e) {
-        AndroidBridge.showToast("保存时间段失败: " + e.message);
+        window.shiguangBridge.showToast("保存时间段失败: " + e.message);
         return;
     }
 
     // 步骤 7：保存课程
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(
+        await window.shiguangBridgePromise.saveImportedCourses(
             JSON.stringify(courses)
         );
     } catch (e) {
-        AndroidBridge.showToast("保存课程失败: " + e.message);
+        window.shiguangBridge.showToast("保存课程失败: " + e.message);
         return;
     }
 
     // 步骤 8：完成
-    AndroidBridge.showToast("成功导入 " + courses.length + " 门课程（" + semesterName + "）");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("成功导入 " + courses.length + " 门课程（" + semesterName + "）");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/UZZ/uzz_01.js
+++ b/resources/UZZ/uzz_01.js
@@ -69,7 +69,7 @@ async function runImportFlow() {
     
     // 强拦截：由于正方系统的 gnmkdm 模块会话校验，必须要求用户在课表页面才能请求 API
     if (!$ || !$('#xnm').length || !$('#xqm').length) {
-        await window.AndroidBridgePromise.showAlert(
+        await window.shiguangBridgePromise.showAlert(
             "导入提示", 
             "正方教务系统限制：请务必先点击进入【正方教务管理系统】->【个人课表查询】页面后，再点击一键导入！", 
             "我知道了"
@@ -77,7 +77,7 @@ async function runImportFlow() {
         return;
     }
 
-    AndroidBridge.showToast("正在获取当前页面课表数据...");
+    window.shiguangBridge.showToast("正在获取当前页面课表数据...");
     
     // 直接静默提取页面上已经选好的学年和学期
     const xnm = $('#xnm').val();
@@ -97,17 +97,17 @@ async function runImportFlow() {
         const courses = parseJsonData(json);
 
         if (courses.length === 0) {
-            await window.AndroidBridgePromise.showAlert("导入失败", "该学年学期未找到课程数据，请确认页面上显示的课表是否为空。", "确定");
+            await window.shiguangBridgePromise.showAlert("导入失败", "该学年学期未找到课程数据，请确认页面上显示的课表是否为空。", "确定");
             return;
         }
 
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TimeSlots));
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (e) {
-        await window.AndroidBridgePromise.showAlert("导入失败", "接口请求异常，请确认教务系统网络通畅。", "确定");
+        await window.shiguangBridgePromise.showAlert("导入失败", "接口请求异常，请确认教务系统网络通畅。", "确定");
         console.error(e);
     }
 }

--- a/resources/WBU/wbu_01.js
+++ b/resources/WBU/wbu_01.js
@@ -2,8 +2,8 @@
 
 (function () {
     function toast(message) {
-        if (window.AndroidBridge && typeof window.AndroidBridge.showToast === "function") {
-            window.AndroidBridge.showToast(message);
+        if (window.shiguangBridge && typeof window.shiguangBridge.showToast === "function") {
+            window.shiguangBridge.showToast(message);
         }
     }
 
@@ -331,17 +331,17 @@
         }
 
         try {
-            const result = await window.AndroidBridgePromise.saveImportedCourses(
+            const result = await window.shiguangBridgePromise.saveImportedCourses(
                 JSON.stringify(courses)
             );
             if (result === true) {
                 if (timeSlots.length) {
-                    await window.AndroidBridgePromise.savePresetTimeSlots(
+                    await window.shiguangBridgePromise.savePresetTimeSlots(
                         JSON.stringify(timeSlots)
                     );
                 }
                 toast("课表导出成功");
-                window.AndroidBridge.notifyTaskCompletion();
+                window.shiguangBridge.notifyTaskCompletion();
             } else {
                 toast("课表导出失败，请查看控制台日志");
             }

--- a/resources/WBU/wbu_02.js
+++ b/resources/WBU/wbu_02.js
@@ -17,8 +17,8 @@
 
 (function () {
     function toast(message) {
-        if (window.AndroidBridge && typeof window.AndroidBridge.showToast === "function") {
-            window.AndroidBridge.showToast(message);
+        if (window.shiguangBridge && typeof window.shiguangBridge.showToast === "function") {
+            window.shiguangBridge.showToast(message);
         }
     }
 
@@ -32,8 +32,8 @@
     // 桥接端是否支持单选弹窗
     function canShowSingleSelection() {
         return !!(
-            window.AndroidBridgePromise &&
-            typeof window.AndroidBridgePromise.showSingleSelection === "function"
+            window.shiguangBridgePromise &&
+            typeof window.shiguangBridgePromise.showSingleSelection === "function"
         );
     }
 
@@ -412,7 +412,7 @@
 
         console.log(`检测到 ${withId.length} 门课的教师姓名带工号，即将弹出询问...`);
         try {
-            const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+            const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
                 `教师姓名带工号（共 ${withId.length} 门课）`,
                 JSON.stringify(options),
                 0
@@ -509,7 +509,7 @@
             "即将弹出询问..."
         );
         try {
-            const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+            const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
                 title,
                 JSON.stringify(options),
                 0
@@ -633,7 +633,7 @@
             );
             let selectedIndex;
             try {
-                selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+                selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
                     pageIndex === 0
                         ? "请选择要导出的学年学期"
                         : "更多学期（第 " + (pageIndex + 1) + " 页 / 共 " + pages.length + " 页）",
@@ -924,7 +924,7 @@
         const defaultIndex = Math.max(0, campuses.findIndex((c) => c.id === defaultId));
         let selectedIndex;
         try {
-            selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+            selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
                 "检测到多个校区且作息不同，请选择要导出的校区",
                 JSON.stringify(labels),
                 defaultIndex
@@ -1056,21 +1056,21 @@
         }
 
         try {
-            const result = await window.AndroidBridgePromise.saveImportedCourses(
+            const result = await window.shiguangBridgePromise.saveImportedCourses(
                 JSON.stringify(courses)
             );
             if (result === true) {
                 if (timeSlots.length) {
-                    await window.AndroidBridgePromise.savePresetTimeSlots(
+                    await window.shiguangBridgePromise.savePresetTimeSlots(
                         JSON.stringify(timeSlots)
                     );
                 }
                 if (
                     semesterConfig &&
-                    window.AndroidBridgePromise &&
-                    typeof window.AndroidBridgePromise.saveCourseConfig === "function"
+                    window.shiguangBridgePromise &&
+                    typeof window.shiguangBridgePromise.saveCourseConfig === "function"
                 ) {
-                    await window.AndroidBridgePromise.saveCourseConfig(
+                    await window.shiguangBridgePromise.saveCourseConfig(
                         JSON.stringify({
                             semesterStartDate: semesterConfig.semesterStartDate,
                             semesterTotalWeeks: semesterConfig.semesterTotalWeeks,
@@ -1078,7 +1078,7 @@
                     );
                 }
                 toast("课表导出成功");
-                window.AndroidBridge.notifyTaskCompletion();
+                window.shiguangBridge.notifyTaskCompletion();
             } else {
                 toast("课表导出失败，请查看控制台日志");
             }

--- a/resources/WENHUA/wenhua_01.js
+++ b/resources/WENHUA/wenhua_01.js
@@ -65,14 +65,14 @@ async function fetchIndexDoc() {
 async function selectTermByUserFromDoc(doc) {
   const { yearData, semesterData } = parseTermOptionsFromDoc(doc);
 
-  const yearIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const yearIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学年',
     JSON.stringify(yearData.options.map(item => item.text)),
     yearData.defaultIndex
   );
   if (yearIndex === null || yearIndex === -1) throw new Error('已取消学年选择');
 
-  const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学期',
     JSON.stringify(semesterData.options.map(item => item.text)),
     semesterData.defaultIndex
@@ -175,7 +175,7 @@ async function fetchTimeSlots(xnm, xqm) {
 async function run() {
   try {
     const { xnm, xqm } = await resolveTerm();
-    AndroidBridge.showToast('正在解析课表数据...');
+    window.shiguangBridge.showToast('正在解析课表数据...');
 
     const rawData = await fetchCourses(xnm, xqm);
     const { courses, xqhId } = parseCourses(rawData);
@@ -185,21 +185,21 @@ async function run() {
     const allWeeks = courses.flatMap(course => course.weeks);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks,
       semesterStartDate: null,
       firstDayOfWeek: 1
     }));
     if (timeSlots && timeSlots.length) {
-      await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+      await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
     }
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：${courses.length} 门`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：${courses.length} 门`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (error) {
     console.error(error);
-    AndroidBridge.showToast(`导入失败: ${error.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${error.message}`);
   }
 }
 

--- a/resources/WHCB/WHCB.js
+++ b/resources/WHCB/WHCB.js
@@ -197,57 +197,57 @@ async function login(){
     const wspc = "authserver.wspc.edu.cn";
     const timeTable = "jw.wspc.edu.cn";
     const currentHost = window.location.host;
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
     "使用前请注意",
     promptMessage,
     "好的"
     );
     if (confirmed) {
         if (currentHost == wspc) {
-        AndroidBridge.showToast("请先登录");
+        window.shiguangBridge.showToast("请先登录");
         return false;
         }
         else if (currentHost ==timeTable) {
             return true;
         }
         else
-            AndroidBridge.showToast("请在学校的网站内导入");
+            window.shiguangBridge.showToast("请在学校的网站内导入");
         }
     else {
-        AndroidBridge.showToast("取消导入操作");
+        window.shiguangBridge.showToast("取消导入操作");
         return false;
     }
 }
 
 async function saveCourses(parsedCourses) {
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 门课程！`);
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存失败: ${error.message}`);
         return false;
     }
 }
 
 async function importPresetTimeSlots(timeSlots) {
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
         return true; // 添加返回值
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         return false; // 添加返回值
     }
 }
 
 async function saveConfig(config) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast("课表配置更新成功！");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast("课表配置更新成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存配置失败: " + error.message);
         return false;
     }
 }
@@ -260,23 +260,23 @@ async function runImportFlow() {
     // 提取课程数据
     const rawCourses = extractCourses();
     if(rawCourses.length === 0){
-        AndroidBridge.showToast("未找到任何课程! 请确认已登录并进入课表页面。");
+        window.shiguangBridge.showToast("未找到任何课程! 请确认已登录并进入课表页面。");
         return;
     }
     const mergedCourses = mergeCourses(rawCourses);
     if(mergedCourses.length === 0){
-        AndroidBridge.showToast("课程合并失败，未生成任何课程数据！");
+        window.shiguangBridge.showToast("课程合并失败，未生成任何课程数据！");
         return;
     }
     const finalCourses = sortCourses(mergedCourses);
     if(finalCourses.length === 0){
-        AndroidBridge.showToast("课程排序失败，未生成任何课程数据！");
+        window.shiguangBridge.showToast("课程排序失败，未生成任何课程数据！");
         return;
     } 
     // 生成时间段数据
     const timeSlots = generateTimeSlots();
     if(timeSlots.length === 0){
-        AndroidBridge.showToast("时间段生成失败，未生成任何时间段数据！");
+        window.shiguangBridge.showToast("时间段生成失败，未生成任何时间段数据！");
         return;
     }
     // 生成配置数据
@@ -296,8 +296,8 @@ async function runImportFlow() {
     if(!configResult){
         return;
     }
-    AndroidBridge.showToast("成功导入课表！请前往设置调整开学时间等信息！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast("成功导入课表！请前往设置调整开学时间等信息！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 执行

--- a/resources/WHUT/whut_01.js
+++ b/resources/WHUT/whut_01.js
@@ -143,13 +143,13 @@ function parseSingleCourse(rawCourse, sectionMap) {
 }
 
 async function promptUserToStart() {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
         "武汉理工大学课表导入",
         "本流程将通过教务系统接口获取您的个人课表与开学时间。\n重要提示:\n导入前请确保您已在浏览器中成功登录教务系统，且未关闭登录窗口。",
         "好的，开始导入"
     );
     if (!confirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return null;
     }
     return true;
@@ -157,7 +157,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear();
-    const yearSelection = await window.AndroidBridgePromise.showPrompt(
+    const yearSelection = await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         String(currentYear), 
@@ -168,7 +168,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["1 (秋季学期/上学期)", "2 (春季学期/下学期)"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -225,7 +225,7 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         studentId = userData?.datas?.userId;
         if (!studentId) throw new Error("无法读取 userId");
     } catch (e) {
-        AndroidBridge.showToast("获取用户信息失败，请确认是否登录教务系统！");
+        window.shiguangBridge.showToast("获取用户信息失败，请确认是否登录教务系统！");
         console.error("Fetch User Error:", e);
         return null;
     }
@@ -270,14 +270,14 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
         });
         rawCourseData = JSON.parse(await response.text());
     } catch (e) {
-        AndroidBridge.showToast("请求课表 API 失败，请检查网络和登录状态。");
+        window.shiguangBridge.showToast("请求课表 API 失败，请检查网络和登录状态。");
         console.error("Fetch Course Error:", e);
         return null;
     }
 
     const rawCourses = rawCourseData?.datas?.cxxskcb?.rows || [];
     if (rawCourses.length === 0) {
-        AndroidBridge.showToast("该学期未查询到您的课程数据。");
+        window.shiguangBridge.showToast("该学期未查询到您的课程数据。");
         return null;
     }
 
@@ -292,15 +292,15 @@ async function fetchAndParseCourses(academicYear, semesterCode) {
 
 async function saveCourses(parsedCourses) {
     if (parsedCourses.length === 0) {
-        AndroidBridge.showToast("没有有效的课程数据可供保存。");
+        window.shiguangBridge.showToast("没有有效的课程数据可供保存。");
         return true;
     }
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
-        AndroidBridge.showToast(`成功导入 ${parsedCourses.length} 个规范后的课程块！`);
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        window.shiguangBridge.showToast(`成功导入 ${parsedCourses.length} 个规范后的课程块！`);
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`保存课程数据失败: ${error.message}`);
+        window.shiguangBridge.showToast(`保存课程数据失败: ${error.message}`);
         return false;
     }
 }
@@ -326,7 +326,7 @@ async function importPresetTimeSlots() {
     ];
 
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         return true; 
     } catch (error) {
         console.error("导入时间段失败: " + error.message);
@@ -336,7 +336,7 @@ async function importPresetTimeSlots() {
 
 async function saveConfig(configData) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(configData));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(configData));
         return true;
     } catch (error) {
         console.error("保存配置失败: " + error.message);
@@ -345,20 +345,20 @@ async function saveConfig(configData) {
 }
 
 async function runImportFlow() {
-    AndroidBridge.showToast("武汉理工大学课程导入流程启动...");
+    window.shiguangBridge.showToast("武汉理工大学课程导入流程启动...");
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) return;
     
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
     
     const semesterCode = await selectSemester();
     if (semesterCode === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -373,7 +373,7 @@ async function runImportFlow() {
     const saveResult = await saveCourses(courseData.courses);
     if (!saveResult) return;
 
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/XATU/myschool.js
+++ b/resources/XATU/myschool.js
@@ -214,7 +214,7 @@ async function getSelectedSemester(tagId) {
     for (let key in data.semesters) {
         data.semesters[key].forEach(s => list.push({ id: s.id, name: `${s.schoolYear} ${s.name}学期` }));
     }
-    const idx = await window.AndroidBridgePromise.showSingleSelection("选择学期", JSON.stringify(list.map(s => s.name)), -1);
+    const idx = await window.shiguangBridgePromise.showSingleSelection("选择学期", JSON.stringify(list.map(s => s.name)), -1);
     return idx !== null ? list[idx] : null;
 }
 
@@ -242,7 +242,7 @@ async function applyTimeSlots() {
         { "number": 11, "startTime": "20:00", "endTime": "20:45" },
         { "number": 12, "startTime": "20:55", "endTime": "21:40" },
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(slots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(slots));
 }
 
 
@@ -263,14 +263,14 @@ function adjustTeachingBuilding3Courses(courses) {
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("开始探测教务参数...");
+        window.shiguangBridge.showToast("开始探测教务参数...");
         const params = await detectParameters();
         if (!params) throw new Error("未能识别教务参数，请确认已登录");
 
         const semester = await getSelectedSemester(params.tagId);
         if (!semester) return; 
 
-        AndroidBridge.showToast("正在同步课表...");
+        window.shiguangBridge.showToast("正在同步课表...");
         let courses = await fetchAndParseCourses(semester.id, params.ids);
         
         if (!courses || courses.length === 0) throw new Error("未解析到课程数据");
@@ -279,15 +279,15 @@ async function runImportFlow() {
         courses = adjustTeachingBuilding3Courses(courses);
 
         await applyTimeSlots();
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         
         if (saveResult) {
-            AndroidBridge.showToast(`成功导入 ${courses.length} 个课程条目`);
-            AndroidBridge.notifyTaskCompletion();
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 个课程条目`);
+            window.shiguangBridge.notifyTaskCompletion();
         }
     } catch (e) {
         console.error(`[异常] ${e.message}`);
-        AndroidBridge.showToast(e.message);
+        window.shiguangBridge.showToast(e.message);
     }
 }
 

--- a/resources/XAUT/XAUT_01.js
+++ b/resources/XAUT/XAUT_01.js
@@ -180,8 +180,8 @@ function extractDataFromDoc(doc) {
  */
 async function runImportFlow() {
     try {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("正在获取课表与作息配置...");
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("正在获取课表与作息配置...");
         } else {
             console.log("正在发起请求获取课表...");
         }
@@ -210,22 +210,22 @@ async function runImportFlow() {
 
         // 第 2 步：选择学期
         let selectedIdx = defaultIndex;
-        if (semesters.length > 0 && typeof window.AndroidBridgePromise !== 'undefined') {
-            let userChoice = await window.AndroidBridgePromise.showSingleSelection(
+        if (semesters.length > 0 && typeof window.shiguangBridgePromise !== 'undefined') {
+            let userChoice = await window.shiguangBridgePromise.showSingleSelection(
                 "请选择要导入的学期", 
                 JSON.stringify(semesters), 
                 defaultIndex
             );
 
             if (userChoice === null) {
-                AndroidBridge.showToast("已取消导入");
+                window.shiguangBridge.showToast("已取消导入");
                 return;
             }
             selectedIdx = userChoice;
             
             // 如果非默认学期，重新获取页面
             if (selectedIdx !== defaultIndex) {
-                AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
+                window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 课表...`);
                 let formData = new URLSearchParams();
                 formData.append('xnxq01id', semesterValues[selectedIdx]);
 
@@ -237,7 +237,7 @@ async function runImportFlow() {
                 const postHtml = await postResponse.text();
                 doc = parser.parseFromString(postHtml, 'text/html');
             }
-        } else if (typeof window.AndroidBridgePromise === 'undefined') {
+        } else if (typeof window.shiguangBridgePromise === 'undefined') {
             // 浏览器环境测验
             let msg = "【浏览器测试】请选择学期序号：\n\n";
             semesters.forEach((s, idx) => msg += `[${idx}] : ${s}\n`);
@@ -266,8 +266,8 @@ async function runImportFlow() {
         
         if (courses.length === 0) {
             const errMsg = "未能解析到任何课程，请检查是否暂无排课。";
-            if (typeof window.AndroidBridgePromise !== 'undefined') {
-                await window.AndroidBridgePromise.showAlert("提示", errMsg, "好的");
+            if (typeof window.shiguangBridgePromise !== 'undefined') {
+                await window.shiguangBridgePromise.showAlert("提示", errMsg, "好的");
             } else {
                 alert(errMsg);
             }
@@ -280,7 +280,7 @@ async function runImportFlow() {
         };
 
         // 浏览器测试输出
-        if (typeof window.AndroidBridgePromise === 'undefined') {
+        if (typeof window.shiguangBridgePromise === 'undefined') {
             console.log("【智能抓取大节时间轴 (剔除12:10-14:00)】\n", timeSlots);
             console.log(`【成功提取去重课程 (${courses.length}门)】\n`, JSON.stringify(courses, null, 2));
             alert(`解析并去重成功！获取到 ${courses.length} 门课程及大节作息。请打开F12查看。`);
@@ -289,22 +289,22 @@ async function runImportFlow() {
 
         // APP 环境保存
         if (timeSlots.length > 0) {
-            await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         }
         
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!saveResult) {
-            AndroidBridge.showToast("保存课程失败，请重试！");
+            window.shiguangBridge.showToast("保存课程失败，请重试！");
             return;
         }
 
-        AndroidBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 节课程及作息时间！`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        if (typeof window.AndroidBridge !== 'undefined') {
-            AndroidBridge.showToast("导入发生异常: " + error.message);
+        if (typeof window.shiguangBridge !== 'undefined') {
+            window.shiguangBridge.showToast("导入发生异常: " + error.message);
         } else {
             console.error("【导入发生异常】", error);
             alert("导入发生异常: " + error.message);

--- a/resources/XAWL/xawl_01.js
+++ b/resources/XAWL/xawl_01.js
@@ -133,7 +133,7 @@ function validateYearInput(input) {
 
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -143,7 +143,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -154,7 +154,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -175,7 +175,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     
@@ -206,14 +206,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -222,21 +222,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses };
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -271,7 +271,7 @@ const SummerTimeSlots = [
 async function selectTimeSlotsType() {
     const timeSlotsOptions = ["非夏季作息", "夏季作息"];
     console.log("JS: 提示用户选择作息时间类型。");
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择作息时间",
         JSON.stringify(timeSlotsOptions),
         0
@@ -283,17 +283,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -302,7 +302,7 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     // 1. 登录检查 (适配西安文理学院登录页)
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         console.log("JS: 检测到当前在登录页面，终止导入。");
         return;
     }
@@ -310,14 +310,14 @@ async function runImportFlow() {
     // 2. 公告和学年学期选择
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -326,7 +326,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -366,9 +366,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(selectedTimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/XJIE/xjie_01.js
+++ b/resources/XJIE/xjie_01.js
@@ -126,7 +126,7 @@ async function saveAppConfig() {
         "semesterTotalWeeks": 20,
         "firstDayOfWeek": 1
     };
-    return await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    return await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 
 /**
@@ -146,7 +146,7 @@ async function saveAppTimeSlots() {
         { "number": 10, "startTime": "19:50", "endTime": "20:35" },
         { "number": 11, "startTime": "20:45", "endTime": "21:30" }
     ];
-    return await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    return await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
 }
 
 /**
@@ -155,12 +155,12 @@ async function saveAppTimeSlots() {
 async function getSelectedSemesterId() {
     const currentYear = new Date().getFullYear();
     // 绑定验证函数 validateYearInput
-    const year = await window.AndroidBridgePromise.showPrompt(
+    const year = await window.shiguangBridgePromise.showPrompt(
         "选择学年", "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:", String(currentYear), "validateYearInput"
     );
     if (!year) return null;
     
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期", JSON.stringify(["第一学期", "第二学期"]), 0
     );
     if (semesterIndex === null) return null;
@@ -172,23 +172,23 @@ async function getSelectedSemesterId() {
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "公告",
             "请确保您已在当前页面成功登录教务系统，否则无法获取数据。是否继续？",
             "确认已登录"
         );
         if (!confirmed) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
         const semesterId = await getSelectedSemesterId();
         if (!semesterId) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         
         const response = await fetch("https://jwxt.xjie.edu.cn/jsxsd/xskb/xskb_list.do", {
             method: "POST",
@@ -201,21 +201,21 @@ async function runImportFlow() {
         const finalCourses = parseTimetableToModel(new DOMParser().parseFromString(html, "text/html"));
 
         if (finalCourses.length === 0) {
-            AndroidBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
+            window.shiguangBridge.showToast("未发现任何课程数据,检查是否登录或者学期选择是否正确");
             return;
         }
 
         // 保存数据
-        AndroidBridge.showToast("正在保存配置...");
+        window.shiguangBridge.showToast("正在保存配置...");
         await saveAppConfig();
         await saveAppTimeSlots();
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
         
-        AndroidBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`成功导入 ${finalCourses.length} 门课程`);
+        window.shiguangBridge.notifyTaskCompletion();
 
     } catch (error) {
-        AndroidBridge.showToast("异常: " + error.message);
+        window.shiguangBridge.showToast("异常: " + error.message);
     }
 }
 

--- a/resources/XJZFU/xjzfu.js
+++ b/resources/XJZFU/xjzfu.js
@@ -107,31 +107,31 @@ async function fetchTermList() {
 
 async function importCourseSchedule() {
     try {
-        AndroidBridge.showToast('正在获取学期列表...');
+        window.shiguangBridge.showToast('正在获取学期列表...');
 
         const termList = await fetchTermList();
 
         let selectedIdx = termList.defaultIndex;
-        if (typeof window.AndroidBridgePromise !== 'undefined') {
-            const choice = await window.AndroidBridgePromise.showSingleSelection(
+        if (typeof window.shiguangBridgePromise !== 'undefined') {
+            const choice = await window.shiguangBridgePromise.showSingleSelection(
                 '请选择要导入的学期',
                 JSON.stringify(termList.termNames),
                 termList.defaultIndex
             );
             if (choice === null) {
-                AndroidBridge.showToast('已取消导入');
+                window.shiguangBridge.showToast('已取消导入');
                 return false;
             }
             selectedIdx = choice;
         }
 
         const termCode = termList.termCodes[selectedIdx];
-        AndroidBridge.showToast('正在获取课表数据...');
+        window.shiguangBridge.showToast('正在获取课表数据...');
         const datas = await fetchScheduleData(termCode);
         const arrangedList = datas.arrangedList || [];
 
         if (arrangedList.length === 0) {
-            AndroidBridge.showToast('未找到课程数据');
+            window.shiguangBridge.showToast('未找到课程数据');
             return false;
         }
 
@@ -156,23 +156,23 @@ async function importCourseSchedule() {
 
         console.log(`找到 ${courses.length} 门课程:`, courses);
 
-        const courseResult = await window.AndroidBridgePromise.saveImportedCourses(
+        const courseResult = await window.shiguangBridgePromise.saveImportedCourses(
             JSON.stringify(courses)
         );
         if (courseResult !== true) {
-            AndroidBridge.showToast('课程导入失败');
+            window.shiguangBridge.showToast('课程导入失败');
             return false;
         }
-        AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！`);
+        window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！`);
 
         const timeSlots = generateTimeSlots(arrangedList);
         console.log('时间段配置:', timeSlots);
 
-        const slotResult = await window.AndroidBridgePromise.savePresetTimeSlots(
+        const slotResult = await window.shiguangBridgePromise.savePresetTimeSlots(
             JSON.stringify(timeSlots)
         );
         if (slotResult === true) {
-            AndroidBridge.showToast('时间段配置成功！');
+            window.shiguangBridge.showToast('时间段配置成功！');
         }
 
         const weeksData = await fetchTermWeeks(termCode);
@@ -185,17 +185,17 @@ async function importCourseSchedule() {
                 defaultBreakDuration: 10,
                 firstDayOfWeek: 1
             };
-            await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+            await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
             console.log('学期配置已保存:', config);
         }
 
-        AndroidBridge.showToast('课表导入完成！');
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast('课表导入完成！');
+        window.shiguangBridge.notifyTaskCompletion();
         return true;
 
     } catch (error) {
         console.error('导入过程出错:', error);
-        AndroidBridge.showToast('导入失败: ' + error.message);
+        window.shiguangBridge.showToast('导入失败: ' + error.message);
         return false;
     }
 }
@@ -204,5 +204,5 @@ if (isOnStudentPage()) {
     console.log('检测到新疆政法学院教务系统');
     setTimeout(() => { importCourseSchedule(); }, 1000);
 } else {
-    AndroidBridge.showToast('请先登录教务系统！');
+    window.shiguangBridge.showToast('请先登录教务系统！');
 }

--- a/resources/XMCU/xmcu_01.js
+++ b/resources/XMCU/xmcu_01.js
@@ -14,7 +14,7 @@ async function checkLoginEnvironment() {
     const targetBase = "https://jws-443.webvpn.xmcu.edu.cn/xmcsjw/";
     
     if (!currentUrl.startsWith(targetBase)) {
-        AndroidBridge.showToast("请先登录教务系统再进行导入");
+        window.shiguangBridge.showToast("请先登录教务系统再进行导入");
         return false;
     }
     return true;
@@ -120,7 +120,7 @@ function parseAndMergeXmcuData(htmlText) {
  */
 async function getYearAndSemester() {
     try {
-        AndroidBridge.showToast("正在获取学期列表...");
+        window.shiguangBridge.showToast("正在获取学期列表...");
         const response = await fetch("https://jws-443.webvpn.xmcu.edu.cn/xmcsjw/frame/droplist/getDropLists.action", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
@@ -129,12 +129,12 @@ async function getYearAndSemester() {
         });
         const list = await response.json();
         const names = list.map(item => item.name);
-        const selectedIndex = await window.AndroidBridgePromise.showSingleSelection("选择导入学期", JSON.stringify(names), 0);
+        const selectedIndex = await window.shiguangBridgePromise.showSingleSelection("选择导入学期", JSON.stringify(names), 0);
         if (selectedIndex === null) return null;
         const [xn, xq] = list[selectedIndex].code.split('-');
         return { xn, xq };
     } catch (error) {
-        AndroidBridge.showToast("获取列表失败");
+        window.shiguangBridge.showToast("获取列表失败");
         return null;
     }
 }
@@ -146,13 +146,13 @@ async function fetchCourses(xn, xq) {
     try {
         const paramsBase64 = encodeParams(xn, xq);
         const url = `https://jws-443.webvpn.xmcu.edu.cn/xmcsjw/student/wsxk.xskcb10319.jsp?params=${paramsBase64}`;
-        AndroidBridge.showToast("正在提取数据...");
+        window.shiguangBridge.showToast("正在提取数据...");
         const response = await fetch(url, { method: "GET", credentials: "include" });
         const arrayBuffer = await response.arrayBuffer();
         const htmlText = new TextDecoder('gbk').decode(arrayBuffer);
         return parseAndMergeXmcuData(htmlText);
     } catch (error) {
-        AndroidBridge.showToast("抓取课表失败");
+        window.shiguangBridge.showToast("抓取课表失败");
         return null;
     }
 }
@@ -174,7 +174,7 @@ async function importPresetTimeSlots() {
         { "number": 10, "startTime": "19:15", "endTime": "20:00" },
         { "number": 11, "startTime": "20:00", "endTime": "20:45" }
     ];
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(slots)).catch(() => {});
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(slots)).catch(() => {});
 }
 
 /**
@@ -186,7 +186,7 @@ async function runImportFlow() {
     if (!isReady) return;
 
     // 弹窗确认
-    const confirmed = await window.AndroidBridgePromise.showAlert("教务导入", "建议在‘课表查询’页面进行导入以确保数据最全。", "确定");
+    const confirmed = await window.shiguangBridgePromise.showAlert("教务导入", "建议在‘课表查询’页面进行导入以确保数据最全。", "确定");
     if (!confirmed) return;
 
     // 选择学期
@@ -196,17 +196,17 @@ async function runImportFlow() {
     // 获取并解析数据
     const courses = await fetchCourses(params.xn, params.xq);
     if (!courses || courses.length === 0) {
-        AndroidBridge.showToast("未找到有效课程");
+        window.shiguangBridge.showToast("未找到有效课程");
         return;
     }
 
     // 存储
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
     await importPresetTimeSlots();
 
     // 完成
-    AndroidBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 启动

--- a/resources/XUST/xust_01.js
+++ b/resources/XUST/xust_01.js
@@ -159,7 +159,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -168,7 +168,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -178,7 +178,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -236,51 +236,51 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             console.error(`Entry failed: ${url}`);
         }
     }
-    AndroidBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查网络环境或登录状态。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         return false;
     }
 }
 
 async function importPresetTimeSlots(timeSlots) {
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
     }
 }
 
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -296,16 +296,16 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
     }
 
     await importPresetTimeSlots(TimeSlots);
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/XYAFU/xyafu_01.js
+++ b/resources/XYAFU/xyafu_01.js
@@ -176,7 +176,7 @@ async function resolveTermSelection() {
     throw new Error('未读取到学期列表，请先进入“学生个人课表”页面');
   }
 
-  const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学期',
     JSON.stringify(options.map(item => item.text)),
     defaultIndex
@@ -395,7 +395,7 @@ async function loadTimetableDoc(term) {
 
 async function runImportFlow() {
   try {
-    const confirmed = await window.AndroidBridgePromise.showAlert(
+    const confirmed = await window.shiguangBridgePromise.showAlert(
       '信阳农林学院教务导入',
       '请确认你已登录教务系统，并且最好已经打开“学生个人课表”页面。',
       '确定，开始导入'
@@ -403,7 +403,7 @@ async function runImportFlow() {
     if (!confirmed) return;
 
     const term = await resolveTermSelection();
-    AndroidBridge.showToast('正在提取青果课表数据...');
+    window.shiguangBridge.showToast('正在提取青果课表数据...');
 
     const timeSlots = term.isSpringSummer ? TIME_SLOTS_SPRING_SUMMER : TIME_SLOTS_AUTUMN_WINTER;
 
@@ -416,19 +416,19 @@ async function runImportFlow() {
     const allWeeks = courses.flatMap(course => course.weeks);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks,
       semesterStartDate: null,
       firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：共 ${courses.length} 门课程`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (error) {
     console.error(error);
-    AndroidBridge.showToast(`导入失败: ${error.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${error.message}`);
   }
 }
 

--- a/resources/XZIT/xzit_01.js
+++ b/resources/XZIT/xzit_01.js
@@ -168,33 +168,33 @@ function buildCourseConfig(courses) {
 }
 
 async function scrapeAndParseCourses() {
-    AndroidBridge.showToast("正在检查页面并抓取课程数据...");
+    window.shiguangBridge.showToast("正在检查页面并抓取课程数据...");
     const tips = "1. 登录徐州工程学院教务系统\n2. 进入学生个人课表页面\n3. 选择正确学年、学期并点击【查询】\n4. 确认页面已显示课表\n5. 点击下方【一键导入】";
 
     try {
         const response = await fetch(window.location.href);
         const text = await response.text();
         if (!text.includes("课表查询")) {
-            await window.AndroidBridgePromise.showAlert("导入失败", `当前页面似乎不是学生课表查询页面。请检查：\n${tips}`, "确定");
+            await window.shiguangBridgePromise.showAlert("导入失败", `当前页面似乎不是学生课表查询页面。请检查：\n${tips}`, "确定");
             return null;
         }
 
         const typeElement = document.querySelector("#shcPDF");
         if (!typeElement) {
-            await window.AndroidBridgePromise.showAlert("导入失败", "未能识别课表视图类型，请确认您已点击查询且课表已加载完毕。", "确定");
+            await window.shiguangBridgePromise.showAlert("导入失败", "未能识别课表视图类型，请确认您已点击查询且课表已加载完毕。", "确定");
             return null;
         }
 
         const type = typeElement.dataset.type;
         const tableElement = document.querySelector(type === "list" ? "#kblist_table" : "#kbgrid_table_0");
         if (!tableElement) {
-            await window.AndroidBridgePromise.showAlert("导入失败", `未能找到课表主体（${type} 视图），请确认您已点击查询且课表已加载完毕。`, "确定");
+            await window.shiguangBridgePromise.showAlert("导入失败", `未能找到课表主体（${type} 视图），请确认您已点击查询且课表已加载完毕。`, "确定");
             return null;
         }
 
         const courses = type === "list" ? parseList() : parseTable();
         if (!courses.length) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查学年学期是否正确或本学期无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查学年学期是否正确或本学期无课。");
             return null;
         }
 
@@ -203,20 +203,20 @@ async function scrapeAndParseCourses() {
             config: buildCourseConfig(courses)
         };
     } catch (error) {
-        AndroidBridge.showToast(`抓取或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`抓取或解析失败: ${error.message}`);
         console.error("JS: Scrape/Parse Error:", error);
-        await window.AndroidBridgePromise.showAlert("抓取或解析失败", `发生错误：${error.message}`, "确定");
+        await window.shiguangBridgePromise.showAlert("抓取或解析失败", `发生错误：${error.message}`, "确定");
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error("JS: Save Courses Error:", error);
         return false;
     }
@@ -224,38 +224,38 @@ async function saveCourses(parsedCourses) {
 
 async function saveCourseConfig(config) {
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error("JS: Save Config Error:", error);
     }
 }
 
 async function importPresetTimeSlots() {
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-        AndroidBridge.showToast("预设时间段导入成功！");
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+        window.shiguangBridge.showToast("预设时间段导入成功！");
     } catch (error) {
-        AndroidBridge.showToast(`导入时间段失败: ${error.message}`);
+        window.shiguangBridge.showToast(`导入时间段失败: ${error.message}`);
         console.error("JS: Save Time Slots Error:", error);
     }
 }
 
 async function runImportFlow() {
-    const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
         "徐州工程学院课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统，并处于课表查询页面且已点击查询。",
         "好的，开始导入"
     );
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     if (typeof window.jQuery === "undefined" && typeof $ === "undefined") {
         const errorMsg = "当前教务系统页面似乎没有加载 jQuery 库。本脚本依赖 jQuery 进行 DOM 解析。";
-        AndroidBridge.showToast(errorMsg);
-        await window.AndroidBridgePromise.showAlert("导入失败", `${errorMsg}\n请尝试刷新页面后重试。`, "确定");
+        window.shiguangBridge.showToast(errorMsg);
+        await window.shiguangBridgePromise.showAlert("导入失败", `${errorMsg}\n请尝试刷新页面后重试。`, "确定");
         return;
     }
 
@@ -272,8 +272,8 @@ async function runImportFlow() {
 
     await saveCourseConfig(config);
     await importPresetTimeSlots();
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/YANGTZEU/yu.js
+++ b/resources/YANGTZEU/yu.js
@@ -280,7 +280,7 @@
 
 
     async function runImportFlow() {
-        if (!window.AndroidBridgePromise) {
+        if (!window.shiguangBridgePromise) {
             throw new Error("AndroidBridgePromise 不可用，无法进行导入交互。");
         }
 
@@ -292,7 +292,7 @@
         });
         const params = parseEntryParams(entryHtml);
         if (!params.studentId || !params.tagId) {
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "参数探测失败",
                 "未能识别学生 ID 或学期组件 tagId，请确认已登录后重试。",
                 "确定"
@@ -311,17 +311,17 @@
             throw new Error("学期列表为空，无法继续导入。");
         }
         const recentSemesters = allSemesters.slice(-8);
-        const selectIndex = await window.AndroidBridgePromise.showSingleSelection(
+        const selectIndex = await window.shiguangBridgePromise.showSingleSelection(
             "请选择导入学期",
             JSON.stringify(recentSemesters.map((s) => s.name || s.id)),
             -1
         );
         if (selectIndex === null) {
-            AndroidBridge.showToast("已取消导入");
+            window.shiguangBridge.showToast("已取消导入");
             return;
         }
         const selectedSemester = recentSemesters[selectIndex];
-        AndroidBridge.showToast("正在获取课表数据...");
+        window.shiguangBridge.showToast("正在获取课表数据...");
 
         // 拉取并解析课表
         const courseHtml = await requestText(`${BASE}/eams/courseTableForStd!courseTable.action?sf_request_type=ajax`, {
@@ -338,24 +338,24 @@
         const courses = parseCoursesFromTaskActivityScript(courseHtml);
         if (courses.length === 0) {
             const debugInfo = extractCourseHtmlDebugInfo(courseHtml);
-            await window.AndroidBridgePromise.showAlert(
+            await window.shiguangBridgePromise.showAlert(
                 "解析失败",
                 `未能从课表响应中识别到课程。\n响应长度: ${debugInfo.responseLength}\n包含 TaskActivity: ${debugInfo.hasTaskActivity}\n包含 unitCount: ${debugInfo.hasUnitCount}`,
                 "确定"
             );
             return;
         }
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(getPresetTimeSlots()));
-        AndroidBridge.showToast(`导入成功，共 ${courses.length} 条课程`);
-        AndroidBridge.notifyTaskCompletion();
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(getPresetTimeSlots()));
+        window.shiguangBridge.showToast(`导入成功，共 ${courses.length} 条课程`);
+        window.shiguangBridge.notifyTaskCompletion();
     }
     (async function bootstrap() {
         try {
             await runImportFlow();
         } catch (error) {
             console.error("导入流程失败:", error);
-            AndroidBridge.showToast(`导入失败：${error && error.message ? error.message : "请检查教务连接"}`);
+            window.shiguangBridge.showToast(`导入失败：${error && error.message ? error.message : "请检查教务连接"}`);
         }
     })();
 })();

--- a/resources/YIBINU/yibinu_01.js
+++ b/resources/YIBINU/yibinu_01.js
@@ -201,7 +201,7 @@ async function fetchExperimentCourses(studentId,yearterm,authorization) {
         
         if (!authorization) {
             console.error('未找到 authorization');
-            AndroidBridge.showToast("未找到登录凭证，请重新登录");
+            window.shiguangBridge.showToast("未找到登录凭证，请重新登录");
             return [];
         }
         const res = await fetch(url, {
@@ -226,7 +226,7 @@ async function fetchExperimentCourses(studentId,yearterm,authorization) {
         if (!res.ok) {
             const errorData = await res.json();
             console.error("错误响应:", errorData);
-            AndroidBridge.showToast(`实验课错误：${errorData.msg || res.status}`);
+            window.shiguangBridge.showToast(`实验课错误：${errorData.msg || res.status}`);
             return {};
         }
 
@@ -235,7 +235,7 @@ async function fetchExperimentCourses(studentId,yearterm,authorization) {
         return data;
     } catch (e) {
         console.error(e);
-        AndroidBridge.showToast("实验课获取失败: " + e.message);
+        window.shiguangBridge.showToast("实验课获取失败: " + e.message);
         return {};
     }
 }
@@ -243,7 +243,7 @@ async function fetchExperimentCourses(studentId,yearterm,authorization) {
 function parseExperimentCoursesData(jsonData) {
     console.log("JS: 解析实验课数据...");
     if (!jsonData || jsonData.code !== 200 || !jsonData.result?.list) {
-        AndroidBridge.showToast("未获取到实验课数据！");
+        window.shiguangBridge.showToast("未获取到实验课数据！");
         return [];
     }
     const rawList = jsonData.result.list;
@@ -299,7 +299,7 @@ async function establishSession() {
 
     } catch (e) {
         console.error("错误：", e);
-        AndroidBridge.showToast("会话连接建立失败，请重试！");
+        window.shiguangBridge.showToast("会话连接建立失败，请重试！");
     }
 }
 
@@ -323,7 +323,7 @@ async function fetchTheoryCourses(yearTerm, studentId) {
         return data;
     } catch (e) {
         console.error("错误：", e);
-        AndroidBridge.showToast("获取课表失败：" + e.message);
+        window.shiguangBridge.showToast("获取课表失败：" + e.message);
         return [];
     }
 }
@@ -348,7 +348,7 @@ async function fetchTermInfo(academicYear,term) {
         return data;
     } catch (e) {
         console.error("错误：", e);
-        AndroidBridge.showToast("学期信息获取失败" );
+        window.shiguangBridge.showToast("学期信息获取失败" );
         return {};
     }
 }
@@ -361,7 +361,7 @@ function parseYearTermJson(jsonData){
         return {};
     }
     if(jsonData.datas?.cxjcs?.rows.length===0){
-        AndroidBridge.showToast("所查询的学期信息为空");
+        window.shiguangBridge.showToast("所查询的学期信息为空");
         return {};
     }
 
@@ -380,7 +380,7 @@ function parseTheoryJson(jsonData) {
         return [];
     }
     if(jsonData.datas?.xskcb?.extParams?.code!==1){
-        AndroidBridge.showToast(jsonData.datas?.xskcb?.extParams?.msg);
+        window.shiguangBridge.showToast(jsonData.datas?.xskcb?.extParams?.msg);
         return [];
     }
 
@@ -418,11 +418,11 @@ function parseTheoryJson(jsonData) {
 //保存课表信息配置
 async function saveAllCourses(courses) {
     try { 
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2)); 
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2)); 
         return true; 
     }
     catch (e) { 
-        AndroidBridge.showToast("课程保存失败"); 
+        window.shiguangBridge.showToast("课程保存失败"); 
         return false; 
     }
 }
@@ -435,7 +435,7 @@ async function saveConfig(semesterTotalWeeks,semesterStartDate) {
         defaultBreakDuration: 5,
         firstDayOfWeek: 1
     };
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 }
 //保存节次信息配置
 function getTimeSlots(){
@@ -457,7 +457,7 @@ function getTimeSlots(){
 }
 async function importTimeSlots() {
     try { 
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(getTimeSlots())); 
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(getTimeSlots())); 
 
     } catch (e) {}
 }
@@ -465,7 +465,7 @@ async function importTimeSlots() {
 // ==================== 用户交互 ====================
 //智慧校园大厅首次执行提示
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "宜宾学院课表导入",
         "导入流程:1.在智慧校园内执行脚本→2.在实验教学系统再次执行脚本→3.等待执行完成。\n所有数据采用请求方式，可以不在课表页面执行，如果您担心，也可以在课表页面确认后再执行脚本；执行中途取消后可以再次点击执行",
         "开始导入",
@@ -474,7 +474,7 @@ async function promptUserToStart() {
 //理论课及学期信息保存后提示
 async function askImportExperiment(theoryNum,startDate) {
     const options = ["继续导入实验课", "仅保存理论课"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         `获取进度:理论课${theoryNum}门,开学日期${startDate!==undefined?startDate:"未知"}`,
         JSON.stringify(options),
         0
@@ -483,7 +483,7 @@ async function askImportExperiment(theoryNum,startDate) {
 //让用户输入学年
 async function getAcademicYear() {
     const startYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入起始学年（如2025-2026填2025）:",
         startYear,
@@ -496,7 +496,7 @@ function validateYearInput(input) {
 //让用户选择学期
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    return await window.AndroidBridgePromise.showSingleSelection(
+    return await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters), 
         0
@@ -504,7 +504,7 @@ async function selectSemester() {
 }
 //准备跳转实验页面的操作提醒
 async function reminderMotion() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "操作提醒(请认真理解！)",
         "在跳转页面后就可以再次点击底部的|执行导入|，不需要登录；\n当然，你也可以登录后去确认你的实验课表，然后再执行导入；\n一句话：跳转页面后一定！一定！一定！要再次点击执行导入！",
         "我已了解下一步操作"
@@ -524,13 +524,13 @@ function isExpLoginPage() {
 // ==================== 1. 理论课流程 ====================
 async function runImportFlow() {
     if (isTheoryLoginPage()) { 
-        AndroidBridge.showToast("请先登录智慧校园！"); 
+        window.shiguangBridge.showToast("请先登录智慧校园！"); 
         return; 
     }
 
     const studentId = localStorage.getItem('ampUserId');
     if (!studentId) {
-        AndroidBridge.showToast("请确保已登录智慧校园！");
+        window.shiguangBridge.showToast("请确保已登录智慧校园！");
         return;
     }
 
@@ -545,7 +545,7 @@ async function runImportFlow() {
     const academicYear = `${startYear}-${Number(startYear)+1}`
     const yearTerm = `${academicYear}-${term}`;
 
-    AndroidBridge.showToast("稍等一下哦,信息获取中");
+    window.shiguangBridge.showToast("稍等一下哦,信息获取中");
     await establishSession();
     const [theoryRes, termInfoRes] = await Promise.all([
         fetchTheoryCourses(yearTerm, studentId),
@@ -577,8 +577,8 @@ async function runImportFlow() {
     await saveConfig(semesterTotalWeeks,semesterStartDate); 
     await importTimeSlots(); 
     await saveAllCourses(theoryCourses);
-    AndroidBridge.showToast(`导入成功！共 ${theoryNum} 门理论课`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功！共 ${theoryNum} 门理论课`);
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 // ==================== 2. 实验课流程 ====================
@@ -587,12 +587,12 @@ async function runExpAutoMerge() {
         const decodeData = JSON.parse(window.name);
         console.log("数据："+window.name)
         if (!decodeData) {
-            AndroidBridge.showToast("未检测到理论课参数，请重新从理论课流程开始！");
+            window.shiguangBridge.showToast("未检测到理论课参数，请重新从理论课流程开始！");
             return;
         }
         const { theoryCourses, yearTerm, studentId,semesterTotalWeeks,semesterStartDate } = decodeData;
         if (!theoryCourses || !yearTerm || !studentId) {
-            AndroidBridge.showToast("参数不完整，请重新导入理论课！");
+            window.shiguangBridge.showToast("参数不完整，请重新导入理论课！");
             return;
         }
         
@@ -608,11 +608,11 @@ async function runExpAutoMerge() {
         const theoryNum = getCourseNum(theoryCourses);
         const expNum = getCourseNum(expCourses);
         
-        AndroidBridge.showToast(`导入成功！理论课${theoryNum}门 + 实验课${expNum}门`);
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(`导入成功！理论课${theoryNum}门 + 实验课${expNum}门`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (err) {
         console.error(err);
-        AndroidBridge.showToast("自动导入失败！请退出重新开始流程");
+        window.shiguangBridge.showToast("自动导入失败！请退出重新开始流程");
     }
 }
 

--- a/resources/YNUFE/ynufe.js
+++ b/resources/YNUFE/ynufe.js
@@ -453,7 +453,7 @@ function generateTimeSlots(campusIdx = 0) {
  * @returns {Promise<Object>} 学期列表数据
  */
 async function getSemesterList() {
-    AndroidBridge.showToast('正在获取学期列表...');
+    window.shiguangBridge.showToast('正在获取学期列表...');
     const response = await fetch('/jsxsd/xskb/xskb_list.do', { method: 'GET', credentials: 'include' });
     const htmlText = await response.text();
     const parser = new DOMParser();
@@ -584,7 +584,7 @@ async function fetchAndParseCourses(html) {
 async function saveCourses(courses) {
     try {
         console.log(`正在保存 ${courses.length} 门课程...`);
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         console.log('课程数据保存成功');
         return true;
     } catch (error) {
@@ -602,7 +602,7 @@ async function importPresetTimeSlots(campusIdx = 0) {
     try {
         console.log('正在导入时间段配置...');
         const presetTimeSlots = generateTimeSlots(campusIdx);
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
         console.log('时间段配置导入成功');
         return true;
     } catch (error) {
@@ -620,7 +620,7 @@ async function importYnufeCourseSchedule() {
     // 检查是否在登录页面
     if (isLoginPage()) {
         console.log('检测到在登录页面，终止导入');
-        AndroidBridge.showToast('请先登录教务系统！');
+        window.shiguangBridge.showToast('请先登录教务系统！');
         return; // 直接返回,不抛出错误,不调用notifyTaskCompletion
     }
     
@@ -646,7 +646,7 @@ async function importYnufeCourseSchedule() {
             // 循环直到用户选择学期才进行下一步(强制不可取消)
             let selectedIdx = null;
             while (true) {
-                selectedIdx = await window.AndroidBridgePromise.showSingleSelection(
+                selectedIdx = await window.shiguangBridgePromise.showSingleSelection(
                     "选择学期", 
                     JSON.stringify(semesters), 
                     -1
@@ -654,15 +654,15 @@ async function importYnufeCourseSchedule() {
                 if (selectedIdx !== null && selectedIdx !== -1) {
                     break;
                 }
-                AndroidBridge.showToast("必须选择一个学期才能继续导入！");
+                window.shiguangBridge.showToast("必须选择一个学期才能继续导入！");
             }
             
             // 获取对应学期的课表HTML
-            AndroidBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 的课表...`);
+            window.shiguangBridge.showToast(`正在获取 [${semesters[selectedIdx]}] 的课表...`);
             targetHtml = await fetchScheduleForSemester(semesterValues[selectedIdx]);
 
             const campuses = ["龙泉校区（默认）", "安宁校区"];
-            selectedCampusIdx = await window.AndroidBridgePromise.showSingleSelection(
+            selectedCampusIdx = await window.shiguangBridgePromise.showSingleSelection(
                 "选择校区",
                 JSON.stringify(campuses),
                 0
@@ -684,11 +684,11 @@ async function importYnufeCourseSchedule() {
             if (targetHtml && targetHtml.includes('kbtable')) {
                 // 找到了课表元素但没有课程,是真的空课表
                 console.log('检测到空课表');
-                AndroidBridge.showToast('当前课表为空');
+                window.shiguangBridge.showToast('当前课表为空');
                 courses = []; // 返回空数组
             } else {
                 // 找不到课表元素,解析失败
-                AndroidBridge.showToast('获取课表失败,请检查网络和页面状态');
+                window.shiguangBridge.showToast('获取课表失败,请检查网络和页面状态');
                 throw new Error('未找到课表数据');
             }
         } else {
@@ -698,28 +698,28 @@ async function importYnufeCourseSchedule() {
         // 保存课程数据
         const saveResult = await saveCourses(courses);
         if (!saveResult) {
-            AndroidBridge.showToast('保存课程失败');
+            window.shiguangBridge.showToast('保存课程失败');
             throw new Error('保存课程数据失败');
         }
 
         // 导入时间段配置
         const timeSlotResult = await importPresetTimeSlots(selectedCampusIdx);
         if (!timeSlotResult) {
-            AndroidBridge.showToast('导入时间段配置失败');
+            window.shiguangBridge.showToast('导入时间段配置失败');
             throw new Error('导入时间段失败');
         }
 
         // 成功
         if (courses.length > 0) {
             const campusName = selectedCampusIdx === 1 ? "安宁校区" : "龙泉校区";
-            AndroidBridge.showToast(`成功导入 ${courses.length} 门课程！（${campusName}）`);
+            window.shiguangBridge.showToast(`成功导入 ${courses.length} 门课程！（${campusName}）`);
         }
         console.log('课程导入完成');
         return true;
 
     } catch (error) {
         console.error('导入过程出错:', error);
-        AndroidBridge.showToast('导入失败: ' + error.message);
+        window.shiguangBridge.showToast('导入失败: ' + error.message);
         return false;
     }
 }
@@ -732,7 +732,7 @@ async function runImportFlow() {
     
     // 只有成功导入时才发送完成信号
     if (success) {
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.notifyTaskCompletion();
     }
     
     return success;

--- a/resources/YXHMC/yxhmc.js
+++ b/resources/YXHMC/yxhmc.js
@@ -135,7 +135,7 @@ function validateYearInput(input) {
  */
 async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统",
         "好的，开始导入"
@@ -148,7 +148,7 @@ async function promptUserToStart() {
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
     console.log("JS: 提示用户输入学年。");
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -163,7 +163,7 @@ async function getAcademicYear() {
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
     console.log("JS: 提示用户选择学期。");
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -184,7 +184,7 @@ function getSemesterCode(semesterIndex) {
  * 请求和解析课程数据
  */
 async function fetchAndParseCourses(academicYear, semesterIndex) {
-    AndroidBridge.showToast("正在请求课表数据...");
+    window.shiguangBridge.showToast("正在请求课表数据...");
 
     const semesterCode = getSemesterCode(semesterIndex);
     const xnmXqmBody = `xnm=${academicYear}&xqm=${semesterCode}&kzlx=ck&xsdm=&kclbdm=`; 
@@ -220,14 +220,14 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
             jsonData = JSON.parse(jsonText);
         } catch (e) {
             console.error('JS: JSON 解析失败，可能是会话过期:', e);
-            AndroidBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
+            window.shiguangBridge.showToast("数据返回格式错误，可能是您未成功登录或会话已过期。");
             return null;
         }
 
         const courses = parseJsonData(jsonData); 
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课，或教务系统需要二次登录。");
             return null;
         }
 
@@ -245,21 +245,21 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         return { courses: courses, config: config }; 
 
     } catch (error) {
-        AndroidBridge.showToast(`请求或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`请求或解析失败: ${error.message}`);
         console.error('JS: Fetch/Parse Error:', error);
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -318,17 +318,17 @@ async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 准备导入 ${timeSlots.length} 个预设时间段。`);
 
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
+        window.shiguangBridge.showToast(`正在导入 ${timeSlots.length} 个预设时间段...`);
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
             console.log("JS: 预设时间段导入成功。");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
             console.error('JS: Save Time Slots Error:', error);
         }
     } else {
-        AndroidBridge.showToast("警告：时间段为空，未导入时间段信息。");
+        window.shiguangBridge.showToast("警告：时间段为空，未导入时间段信息。");
         console.warn("JS: 警告：传入时间段为空，未导入时间段信息。");
     }
 }
@@ -343,14 +343,14 @@ async function runImportFlow() {
 
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         console.log("JS: 用户取消了导入流程。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 获取学年失败/取消，流程终止。");
         return;
     }
@@ -359,7 +359,7 @@ async function runImportFlow() {
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         console.log("JS: 选择学期失败/取消，流程终止。");
         return;
     }
@@ -379,10 +379,10 @@ async function runImportFlow() {
     }
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast(`课表配置更新成功！总周数：${config.semesterTotalWeeks}周。`);
     } catch (error) {
-        AndroidBridge.showToast(`课表配置保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课表配置保存失败: ${error.message}`);
         console.error('JS: Save Config Error:', error);
     }
 
@@ -390,9 +390,9 @@ async function runImportFlow() {
     await importPresetTimeSlots(TimeSlots);
 
 
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/YZU/yzu.js
+++ b/resources/YZU/yzu.js
@@ -4,7 +4,7 @@
 const PAGE_URL = window.location.href;
 const VPN_BASE = (PAGE_URL.match(/^(https?:\/\/[^/]+\/http[^/]*\/[^/]+)/) || [])[1];
 if (!VPN_BASE) {
-    AndroidBridge.showToast("请通过扬州大学 WebVPN 进入教务系统后使用");
+    window.shiguangBridge.showToast("请通过扬州大学 WebVPN 进入教务系统后使用");
     throw new Error("无法定位 WebVPN 基址");
 }
 
@@ -92,7 +92,7 @@ const FALLBACK_TIME_SLOTS = [
 
 async function runImportFlow() {
     try {
-        const confirmed = await window.AndroidBridgePromise.showAlert(
+        const confirmed = await window.shiguangBridgePromise.showAlert(
             "扬州大学课表导入",
             "请确认：\n1. 已登录扬州大学 WebVPN(webvpn.yzu.edu.cn)\n2. 已进入教务「我的课表」页面（能看到学期下拉框）\n未在课表页会导致获取失败。",
             "好的，开始导入"
@@ -101,7 +101,7 @@ async function runImportFlow() {
 
         const select = document.getElementById("planCode");
         if (!select || select.options.length === 0) {
-            AndroidBridge.showToast("未找到学期选择框，请先进入课表页面");
+            window.shiguangBridge.showToast("未找到学期选择框，请先进入课表页面");
             return;
         }
         const texts = [];
@@ -111,17 +111,17 @@ async function runImportFlow() {
             values.push(select.options[i].value);
         }
         const defaultIndex = select.selectedIndex >= 0 ? select.selectedIndex : 0;
-        const idx = await window.AndroidBridgePromise.showSingleSelection(
+        const idx = await window.shiguangBridgePromise.showSingleSelection(
             "选择学期",
             JSON.stringify(texts),
             defaultIndex
         );
         if (idx === null || idx < 0) {
-            AndroidBridge.showToast("导入已取消");
+            window.shiguangBridge.showToast("导入已取消");
             return;
         }
 
-        AndroidBridge.showToast("正在获取教务数据...");
+        window.shiguangBridge.showToast("正在获取教务数据...");
         const res = await fetch(VPN_BASE + API_PATH, {
             "headers": {
                 "Accept": "application/json, text/javascript, */*; q=0.01",
@@ -137,24 +137,24 @@ async function runImportFlow() {
         const data = await res.json();
         const courses = parseCourses(data);
         if (courses.length === 0) {
-            AndroidBridge.showToast("未解析到课程数据，请确认所选学期有课");
+            window.shiguangBridge.showToast("未解析到课程数据，请确认所选学期有课");
             return;
         }
 
         const timeSlots = parseTimeSlots(data);
-        const ok = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const ok = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!ok) {
-            AndroidBridge.showToast("课程保存失败");
+            window.shiguangBridge.showToast("课程保存失败");
             return;
         }
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots.length ? timeSlots : FALLBACK_TIME_SLOTS));
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks: 20 }));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots.length ? timeSlots : FALLBACK_TIME_SLOTS));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({ semesterTotalWeeks: 20 }));
 
-        AndroidBridge.showToast("成功导入 " + courses.length + " 个课程时段");
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast("成功导入 " + courses.length + " 个课程时段");
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (e) {
         console.error("导入异常:", e);
-        AndroidBridge.showToast("导入失败: " + e.message);
+        window.shiguangBridge.showToast("导入失败: " + e.message);
     }
 }
 

--- a/resources/ZCMU/zcmu.js
+++ b/resources/ZCMU/zcmu.js
@@ -118,7 +118,7 @@ function validateYearInput(input) {
 }
 
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已登录教务系统并进入课表查询页面",
         "好的，开始导入"
@@ -127,7 +127,7 @@ async function promptUserToStart() {
 
 async function getAcademicYear() {
     const currentYear = new Date().getFullYear().toString();
-    return await window.AndroidBridgePromise.showPrompt(
+    return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
         "请输入要导入课程的起始学年（例如 2025-2026 应输入2025）:",
         currentYear,
@@ -137,7 +137,7 @@ async function getAcademicYear() {
 
 async function selectSemester() {
     const semesters = ["第一学期", "第二学期"];
-    const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(semesters),
         0
@@ -188,17 +188,17 @@ async function fetchAndParseCourses(academicYear, semesterIndex) {
         console.error("获取课表失败: " + e);
     }
 
-    AndroidBridge.showToast("未能获取课表数据，请检查是否已登录并进入课表页面。");
+    window.shiguangBridge.showToast("未能获取课表数据，请检查是否已登录并进入课表页面。");
     return null;
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
+    window.shiguangBridge.showToast("正在保存 " + parsedCourses.length + " 门课程...");
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses));
         return true;
     } catch (error) {
-        AndroidBridge.showToast("课程保存失败: " + error.message);
+        window.shiguangBridge.showToast("课程保存失败: " + error.message);
         return false;
     }
 }
@@ -239,7 +239,7 @@ const CampusTimeSlots = {
 
 async function selectCampus() {
     const campuses = Object.keys(CampusTimeSlots);
-    const campusIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const campusIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择校区",
         JSON.stringify(campuses),
         0
@@ -250,12 +250,12 @@ async function selectCampus() {
 
 async function importPresetTimeSlots(timeSlots) {
     if (timeSlots.length > 0) {
-        AndroidBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
+        window.shiguangBridge.showToast("正在导入 " + timeSlots.length + " 个预设时间段...");
         try {
-            await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
-            AndroidBridge.showToast("预设时间段导入成功！");
+            await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+            window.shiguangBridge.showToast("预设时间段导入成功！");
         } catch (error) {
-            AndroidBridge.showToast("导入时间段失败: " + error.message);
+            window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         }
     }
 }
@@ -263,25 +263,25 @@ async function importPresetTimeSlots(timeSlots) {
 async function runImportFlow() {
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
 
     const academicYear = await getAcademicYear();
     if (academicYear === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const semesterIndex = await selectSemester();
     if (semesterIndex === null || semesterIndex === -1) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
     const campus = await selectCampus();
     if (campus === null) {
-        AndroidBridge.showToast("导入已取消。");
+        window.shiguangBridge.showToast("导入已取消。");
         return;
     }
 
@@ -293,16 +293,16 @@ async function runImportFlow() {
     if (!saveResult) return;
 
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-        AndroidBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+        window.shiguangBridge.showToast("课表配置更新成功！总周数：" + config.semesterTotalWeeks + "周。");
     } catch (error) {
-        AndroidBridge.showToast("课表配置保存失败: " + error.message);
+        window.shiguangBridge.showToast("课表配置保存失败: " + error.message);
     }
 
     await importPresetTimeSlots(CampusTimeSlots[campus]);
 
-    AndroidBridge.showToast(campus + "课程导入成功，共导入 " + courses.length + " 门课程！");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(campus + "课程导入成功，共导入 " + courses.length + " 门课程！");
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();

--- a/resources/ZHKU/zhku_lc6464.js
+++ b/resources/ZHKU/zhku_lc6464.js
@@ -147,7 +147,7 @@ async function chooseCampus() {
 
 	let selectedIndex = null;
 	do {
-		selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+		selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
 			"校区检测失败，请选择校区",
 			JSON.stringify(labels),
 			-1
@@ -443,7 +443,7 @@ async function fetchSemesterCalendarInfo(semesterId) {
 
 // 主流程：读取课表 -> 选择校区 -> 拉周历 -> 生成节次 -> 调桥接导入
 async function importSchedule() {
-	AndroidBridge.showToast("开始读取教务课表……");
+	window.shiguangBridge.showToast("开始读取教务课表……");
 
 	// 读取 iframe 并获取当前学年学期 ID
 	const iframeDoc = getScheduleIframeDocument();
@@ -474,12 +474,12 @@ async function importSchedule() {
 	};
 
 	// 通知课表软件进行导入，传递课程与预设时间配置
-	await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-	await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
-	await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+	await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+	await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(presetTimeSlots));
+	await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
 
-	AndroidBridge.showToast(`导入成功：${campusLabel}，课程 ${courses.length} 条`);
-	AndroidBridge.notifyTaskCompletion();
+	window.shiguangBridge.showToast(`导入成功：${campusLabel}，课程 ${courses.length} 条`);
+	window.shiguangBridge.notifyTaskCompletion();
 }
 
 // 自执行入口
@@ -489,6 +489,6 @@ async function importSchedule() {
 	} catch (error) {
 		console.error("课表导入失败：", error);
 		// 失败原因直接提示给用户，便于在移动端快速定位问题
-		AndroidBridge.showToast(`导入失败：${error.message}`);
+		window.shiguangBridge.showToast(`导入失败：${error.message}`);
 	}
 })();

--- a/resources/ZJUT/zjut_01.js
+++ b/resources/ZJUT/zjut_01.js
@@ -78,14 +78,14 @@ async function fetchIndexDoc() {
 async function selectTermByUserFromDoc(doc) {
   const { yearData, semesterData } = parseTermOptionsFromDoc(doc);
 
-  const yearIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const yearIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学年',
     JSON.stringify(yearData.options.map(item => item.text)),
     yearData.defaultIndex
   );
   if (yearIndex === null || yearIndex === -1) throw new Error('已取消学年选择');
 
-  const semesterIndex = await window.AndroidBridgePromise.showSingleSelection(
+  const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
     '选择学期',
     JSON.stringify(semesterData.options.map(item => item.text)),
     semesterData.defaultIndex
@@ -173,7 +173,7 @@ async function fetchCourses(xnm, xqm) {
 async function run() {
   try {
     const { xnm, xqm } = await resolveTerm();
-    AndroidBridge.showToast('正在解析课表数据...');
+    window.shiguangBridge.showToast('正在解析课表数据...');
 
     const rawData = await fetchCourses(xnm, xqm);
     const { courses } = parseCourses(rawData);
@@ -182,19 +182,19 @@ async function run() {
     const allWeeks = courses.flatMap(course => course.weeks);
     const semesterTotalWeeks = allWeeks.length ? Math.max(...allWeeks) : 20;
 
-    await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
       semesterTotalWeeks,
       semesterStartDate: null,
       firstDayOfWeek: 1
     }));
-    await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
-    await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(TIME_SLOTS));
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
 
-    AndroidBridge.showToast(`导入成功：${courses.length} 门`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功：${courses.length} 门`);
+    window.shiguangBridge.notifyTaskCompletion();
   } catch (error) {
     console.error(error);
-    AndroidBridge.showToast(`导入失败: ${error.message}`);
+    window.shiguangBridge.showToast(`导入失败: ${error.message}`);
   }
 }
 

--- a/resources/ZUA/zua.js
+++ b/resources/ZUA/zua.js
@@ -364,7 +364,7 @@ async function getSelectedSemester(tagId, currentSemesterId) {
 
     const selectedId = currentSemesterId || parsed.currentSemesterId;
     const defaultIndex = parsed.semesters.findIndex(semester => semester.id === selectedId);
-    const index = await window.AndroidBridgePromise.showSingleSelection(
+    const index = await window.shiguangBridgePromise.showSingleSelection(
         "选择学期",
         JSON.stringify(parsed.semesters.map(semester => semester.name)),
         defaultIndex
@@ -408,7 +408,7 @@ async function fetchCalendarInfo(semesterId) {
 async function trySaveCalendarInfo(semesterId) {
     try {
         const calendarInfo = await fetchCalendarInfo(semesterId);
-        const saveResult = await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify({
+        const saveResult = await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify({
             semesterStartDate: calendarInfo.semesterStartDate,
             semesterTotalWeeks: calendarInfo.semesterTotalWeeks,
             firstDayOfWeek: calendarInfo.firstDayOfWeek
@@ -422,7 +422,7 @@ async function trySaveCalendarInfo(semesterId) {
 
 async function trySaveTimeSlots() {
     try {
-        const saveResult = await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(getZuaTimeSlots()));
+        const saveResult = await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(getZuaTimeSlots()));
         return saveResult === true;
     } catch (error) {
         console.warn(`[ZUA 作息时间设置失败] ${error.message}`);
@@ -441,27 +441,27 @@ function buildCompletionMessage(calendarSaved, timeSlotsSaved) {
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("开始探测郑航教务参数...");
+        window.shiguangBridge.showToast("开始探测郑航教务参数...");
         const params = await detectParameters();
         if (!params) throw new Error("未能识别教务参数，请确认已登录郑航教务系统");
 
         const semester = await getSelectedSemester(params.tagId, params.currentSemesterId);
         if (!semester) return;
 
-        AndroidBridge.showToast("正在同步课表...");
+        window.shiguangBridge.showToast("正在同步课表...");
         const courses = await fetchAndParseCourses(semester.id, params.ids);
         if (!courses || courses.length === 0) throw new Error("未解析到课程数据");
 
-        const saveResult = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        const saveResult = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
         if (!saveResult) throw new Error("课程保存失败");
 
         const calendarSaved = await trySaveCalendarInfo(semester.id);
         const timeSlotsSaved = await trySaveTimeSlots();
-        AndroidBridge.showToast(buildCompletionMessage(calendarSaved, timeSlotsSaved));
-        AndroidBridge.notifyTaskCompletion();
+        window.shiguangBridge.showToast(buildCompletionMessage(calendarSaved, timeSlotsSaved));
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
         console.error(`[ZUA 课表导入异常] ${error.message}`);
-        AndroidBridge.showToast(error.message);
+        window.shiguangBridge.showToast(error.message);
     }
 }
 

--- a/resources/chaoxing_jiaowu/chaoxing.js
+++ b/resources/chaoxing_jiaowu/chaoxing.js
@@ -251,7 +251,7 @@ async function selectAcademicYearAndSemester(xnxqSelectHtml) {
     }
     const { labels, values, defaultIndex } = options;
     
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择学年学期",
         JSON.stringify(labels),
         defaultIndex
@@ -313,7 +313,7 @@ async function fetchCampusList() {
         console.log(`JS: 校区列表获取成功，共 ${campusList.length} 个校区。`);
         return campusList;
     } catch (error) {
-        AndroidBridge.showToast(`获取校区列表失败: ${error.message}`);
+        window.shiguangBridge.showToast(`获取校区列表失败: ${error.message}`);
         console.error('JS: fetchCampusList Error:', error);
         return null;
     }
@@ -328,7 +328,7 @@ async function selectCampus(defaultXqdm) {
     const campusList = await fetchCampusList();
     if (!campusList) {
         console.warn(`JS: 获取校区列表失败，使用页面参数 xqdm=${defaultXqdm} 继续导入。`);
-        AndroidBridge.showToast("获取校区列表失败，使用默认校区继续导入。");
+        window.shiguangBridge.showToast("获取校区列表失败，使用默认校区继续导入。");
         return {
             xqdm: defaultXqdm,
             xqmc: ""
@@ -341,7 +341,7 @@ async function selectCampus(defaultXqdm) {
         0
     );
 
-    const selectedIndex = await window.AndroidBridgePromise.showSingleSelection(
+    const selectedIndex = await window.shiguangBridgePromise.showSingleSelection(
         "选择校区",
         JSON.stringify(labels),
         defaultIndex
@@ -452,7 +452,7 @@ async function extractPageParams() {
  */
 async function fetchTimeAndWeekData(xnxq, xqdm) {
     console.log(`JS: 正在请求节次时间和周次数据...`);
-    AndroidBridge.showToast("正在获取课表配置信息...");
+    window.shiguangBridge.showToast("正在获取课表配置信息...");
     
     const url = `/admin/api/getZclistByXnxq?xnxq=${xnxq}&xqid=${xqdm}`;
     
@@ -494,7 +494,7 @@ async function fetchTimeAndWeekData(xnxq, xqdm) {
         return { timeSlots, semesterStartDate };
 
     } catch (error) {
-        AndroidBridge.showToast(`获取配置信息失败，将继续导入课程: ${error.message}`);
+        window.shiguangBridge.showToast(`获取配置信息失败，将继续导入课程: ${error.message}`);
         console.error('JS: fetchTimeAndWeekData Error:', error);
         return {
             timeSlots: null,
@@ -512,7 +512,7 @@ async function fetchTimeAndWeekData(xnxq, xqdm) {
  */
 async function fetchCourseData(xnxq, xhid, xqdm) {
     console.log(`JS: 正在请求课程数据...`);
-    AndroidBridge.showToast(`正在获取 ${xnxq} 的课程数据...`);
+    window.shiguangBridge.showToast(`正在获取 ${xnxq} 的课程数据...`);
     
     const url = `/admin/xsd/pkgl/xskb/sdpkkbList?xnxq=${xnxq}&xhid=${xhid}&xqdm=${xqdm}&xskbxslx=0`;
     
@@ -541,7 +541,7 @@ async function fetchCourseData(xnxq, xhid, xqdm) {
         const courses = parseCourseData(jsonData);
 
         if (courses.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，本学期可能无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，本学期可能无课。");
             return null;
         }
 
@@ -549,7 +549,7 @@ async function fetchCourseData(xnxq, xhid, xqdm) {
         return courses;
 
     } catch (error) {
-        AndroidBridge.showToast(`获取课程数据失败: ${error.message}`);
+        window.shiguangBridge.showToast(`获取课程数据失败: ${error.message}`);
         console.error('JS: fetchCourseData Error:', error);
         return null;
     }
@@ -562,14 +562,14 @@ async function fetchCourseData(xnxq, xhid, xqdm) {
  */
 async function saveCourses(courses) {
     console.log(`JS: 正在保存 ${courses.length} 门课程...`);
-    AndroidBridge.showToast(`正在保存 ${courses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${courses.length} 门课程...`);
     
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2));
         console.log("JS: 课程保存成功。");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: saveCourses Error:', error);
         return false;
     }
@@ -582,14 +582,14 @@ async function saveCourses(courses) {
  */
 async function importPresetTimeSlots(timeSlots) {
     console.log(`JS: 正在导入 ${timeSlots.length} 个预设时间段...`);
-    AndroidBridge.showToast(`正在导入作息时间...`);
+    window.shiguangBridge.showToast(`正在导入作息时间...`);
     
     try {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(timeSlots));
         console.log("JS: 预设时间段导入成功。");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("导入时间段失败: " + error.message);
+        window.shiguangBridge.showToast("导入时间段失败: " + error.message);
         console.error('JS: importPresetTimeSlots Error:', error);
         return false;
     }
@@ -613,11 +613,11 @@ async function saveCourseConfig(semesterStartDate) {
     };
     
     try {
-        await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
+        await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
         console.log("JS: 课表配置保存成功。");
         return true;
     } catch (error) {
-        AndroidBridge.showToast("保存课表配置失败: " + error.message);
+        window.shiguangBridge.showToast("保存课表配置失败: " + error.message);
         console.error('JS: saveCourseConfig Error:', error);
         return false;
     }
@@ -637,7 +637,7 @@ function isLoginPage() {
  * @returns {Promise<boolean>} - 用户是否确认
  */
 async function promptUserToStart() {
-    return await window.AndroidBridgePromise.showAlert(
+    return await window.shiguangBridgePromise.showAlert(
         "超星教务系统课表导入",
         "导入前请确保您已在成功登录教务系统，并打开课表页面。\n\n本脚本将自动获取作息时间、开学日期和课程数据。",
         "开始导入"
@@ -652,21 +652,21 @@ async function runImportFlow() {
     
     // 1. 检查是否在登录页面
     if (isLoginPage()) {
-        AndroidBridge.showToast("导入失败：请先登录教务系统！");
+        window.shiguangBridge.showToast("导入失败：请先登录教务系统！");
         return;
     }
 
     // 2. 提示用户确认开始导入
     const alertConfirmed = await promptUserToStart();
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
     
     // 3. 提取页面参数
     const params = await extractPageParams();
     if (!params) {
-        AndroidBridge.showToast("无法从页面获取必要参数，请确保在正确的页面执行脚本。");
+        window.shiguangBridge.showToast("无法从页面获取必要参数，请确保在正确的页面执行脚本。");
         return;
     }
     
@@ -675,14 +675,14 @@ async function runImportFlow() {
     // 4. 让用户选择学年学期
     const xnxq = await selectAcademicYearAndSemester(xnxqSelectHtml);
     if (xnxq === null) {
-        AndroidBridge.showToast("导入已取消，未选择学年学期。");
+        window.shiguangBridge.showToast("导入已取消，未选择学年学期。");
         return;
     }
 
     // 5. 让用户选择校区（默认使用页面参数中的 xqdm，若校区接口失败则自动回退使用页面 xqdm）
     const selectedCampus = await selectCampus(pageXqdm);
     if (!selectedCampus) {
-        AndroidBridge.showToast("导入已取消，未选择校区。");
+        window.shiguangBridge.showToast("导入已取消，未选择校区。");
         return;
     }
     const { xqdm } = selectedCampus;
@@ -718,8 +718,8 @@ async function runImportFlow() {
     }
 
     // 11. 完成
-    AndroidBridge.showToast(`导入成功！共导入 ${courses.length} 门课程。`);
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.showToast(`导入成功！共导入 ${courses.length} 门课程。`);
+    window.shiguangBridge.notifyTaskCompletion();
     console.log("JS: 超星教务系统课表导入流程完成。");
 }
 

--- a/resources/qingguo_jiaowu/qingguo_01.js
+++ b/resources/qingguo_jiaowu/qingguo_01.js
@@ -128,17 +128,17 @@ async function fetchAndParseCourses() {
 
 async function runImportFlow() {
     try {
-        AndroidBridge.showToast("正在合并课表数据...");
+        window.shiguangBridge.showToast("正在合并课表数据...");
         const courses = await fetchAndParseCourses();
         if (!courses || courses.length === 0) {
-            AndroidBridge.showToast("未找到可导入课程");
+            window.shiguangBridge.showToast("未找到可导入课程");
             return;
         }
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(courses));
-        AndroidBridge.showToast(`成功：已优化合并为 ${courses.length} 个课块`);
-        AndroidBridge.notifyTaskCompletion();
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses));
+        window.shiguangBridge.showToast(`成功：已优化合并为 ${courses.length} 个课块`);
+        window.shiguangBridge.notifyTaskCompletion();
     } catch (error) {
-        AndroidBridge.showToast("解析失败: " + error.message);
+        window.shiguangBridge.showToast("解析失败: " + error.message);
     }
 }
 

--- a/resources/urp_jiaowu/urp_01.js
+++ b/resources/urp_jiaowu/urp_01.js
@@ -90,7 +90,7 @@ function parseTimeSlots() {
  */
 async function fetchAndParseJwData() {
     try {
-        AndroidBridge.showToast("正在解析网页课表...");
+        window.shiguangBridge.showToast("正在解析网页课表...");
         
         let courses = [];
         
@@ -145,7 +145,7 @@ async function fetchAndParseJwData() {
         return { courses, timeSlots };
     } catch (e) {
         console.error("HTML解析失败详情:", e);
-        AndroidBridge.showToast("同步失败: " + e.message);
+        window.shiguangBridge.showToast("同步失败: " + e.message);
         return null;
     }
 }
@@ -154,11 +154,11 @@ async function fetchAndParseJwData() {
  * 辅助：保存数据到外部 APP
  */
 async function saveToApp(result) {
-    const courseSuccess = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
+    const courseSuccess = await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(result.courses));
     if (!courseSuccess) return false;
 
     if (result.timeSlots && result.timeSlots.length > 0) {
-        await window.AndroidBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(result.timeSlots));
     }
     return true;
 }
@@ -167,7 +167,7 @@ async function saveToApp(result) {
  * 流程控制流程
  */
 async function runImportFlow() {
-    const alertResult = await window.AndroidBridgePromise.showAlert(
+    const alertResult = await window.shiguangBridgePromise.showAlert(
         "教务网页课表导入",
         "请确保您当前的网页已加载出课表视图后再开始导入",
         "开始同步"
@@ -178,8 +178,8 @@ async function runImportFlow() {
     if (!result || result.courses.length === 0) return;
 
     if (await saveToApp(result)) {
-        AndroidBridge.showToast(`成功从网页导入 ${result.courses.length} 个课程时段`);
-        AndroidBridge.notifyTaskCompletion(); 
+        window.shiguangBridge.showToast(`成功从网页导入 ${result.courses.length} 个课程时段`);
+        window.shiguangBridge.notifyTaskCompletion(); 
     }
 }
 

--- a/resources/zhengfang_jiaowu/zhengfang_01.js
+++ b/resources/zhengfang_jiaowu/zhengfang_01.js
@@ -163,27 +163,27 @@ function parserWeeks(str) {
 }
 
 async function scrapeAndParseCourses() {
-    AndroidBridge.showToast("正在检查页面并抓取课程数据...");
+    window.shiguangBridge.showToast("正在检查页面并抓取课程数据...");
     const ts = `1.登陆教务系统\n2.导航到学生课表查询页面\n3.等待课表信息加载，选择对应学年、学期，确认无误后点击【查询】\n4.确保页面上显示了课程表\n5.点击下方【一键导入】`
     try {
         const response = await fetch(window.location.href);
         const text = await response.text();
         if (!text.includes("课表查询")) {
             console.log("页面内容检查失败！");
-            await window.AndroidBridgePromise.showAlert("导入失败", "当前页面似乎不是学生课表查询页面。请检查：\n" + ts, "确定"); 
+            await window.shiguangBridgePromise.showAlert("导入失败", "当前页面似乎不是学生课表查询页面。请检查：\n" + ts, "确定"); 
             return null;
         }
         const typeElement = document.querySelector('#shcPDF');
         if (!typeElement) {
              console.log("未能找到视图类型元素 (#shcPDF)");
-             await window.AndroidBridgePromise.showAlert("导入失败", "未能识别课表视图类型，请确认您已点击查询且课表已加载完毕。", "确定");
+             await window.shiguangBridgePromise.showAlert("导入失败", "未能识别课表视图类型，请确认您已点击查询且课表已加载完毕。", "确定");
              return null;
         }
         const type = typeElement.dataset['type'];
         const tableElement = document.querySelector(type === 'list' ? '#kblist_table' : '#kbgrid_table_0');
         if (!tableElement) {
              console.log("未能找到课表主体 HTML");
-             await window.AndroidBridgePromise.showAlert("导入失败", `未能找到课表主体 (${type} 视图)，请确认您已点击查询且课表已加载完毕。`, "确定");
+             await window.shiguangBridgePromise.showAlert("导入失败", `未能找到课表主体 (${type} 视图)，请确认您已点击查询且课表已加载完毕。`, "确定");
              return null;
         }
         let result = [];
@@ -193,28 +193,28 @@ async function scrapeAndParseCourses() {
             result = parserTbale(); 
         }
         if (result.length === 0) {
-            AndroidBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
             return null;
         }
         console.log(`JS: 课程数据解析成功，共找到 ${result.length} 门课程。`);
         return { courses: result };
     } catch (error) {
-        AndroidBridge.showToast(`抓取或解析失败: ${error.message}`);
+        window.shiguangBridge.showToast(`抓取或解析失败: ${error.message}`);
         console.error('JS: Scrape/Parse Error:', error);
-        await window.AndroidBridgePromise.showAlert("抓取或解析失败", `发生错误：${error.message}。请重试或联系开发者。`, "确定");
+        await window.shiguangBridgePromise.showAlert("抓取或解析失败", `发生错误：${error.message}。请重试或联系开发者。`, "确定");
         return null;
     }
 }
 
 async function saveCourses(parsedCourses) {
-    AndroidBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
     console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
     try {
-        await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
         console.log("JS: 课程保存成功！");
         return true;
     } catch (error) {
-        AndroidBridge.showToast(`课程保存失败: ${error.message}`);
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
         console.error('JS: Save Courses Error:', error);
         return false;
     }
@@ -222,20 +222,20 @@ async function saveCourses(parsedCourses) {
 
 
 async function runImportFlow() {
-    const alertConfirmed = await window.AndroidBridgePromise.showAlert(
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
         "教务系统课表导入",
         "导入前请确保您已在浏览器中成功登录教务系统，并处于课表查询页面且已点击查询。",
         "好的，开始导入"
     );
     if (!alertConfirmed) {
-        AndroidBridge.showToast("用户取消了导入。");
+        window.shiguangBridge.showToast("用户取消了导入。");
         return;
     }
     
     if (typeof window.jQuery === 'undefined' && typeof $ === 'undefined') {
         const errorMsg = "当前教务系统页面似乎没有加载 jQuery 库。本脚本依赖 jQuery 进行 DOM 解析。";
-        AndroidBridge.showToast(errorMsg);
-        await window.AndroidBridgePromise.showAlert("导入失败", errorMsg + "\n请尝试刷新页面或使用其他导入方式。", "确定");
+        window.shiguangBridge.showToast(errorMsg);
+        await window.shiguangBridgePromise.showAlert("导入失败", errorMsg + "\n请尝试刷新页面或使用其他导入方式。", "确定");
         console.error("JS: 缺少 jQuery 依赖，流程终止。");
         return;
     }
@@ -253,9 +253,9 @@ async function runImportFlow() {
         return;
     }
     
-    AndroidBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
-    AndroidBridge.notifyTaskCompletion();
+    window.shiguangBridge.notifyTaskCompletion();
 }
 
 runImportFlow();


### PR DESCRIPTION
将多个教务导入脚本中对宿主桥接对象的调用从 AndroidBridge/AndroidBridgePromise 切换为 window.shiguangBridge/window.shiguangBridgePromise；同时替换相关方法调用。此变更仅为桥接层适配，不修改课程解析或业务逻辑。