### PR TITLE
feat: 自动读取广东海洋大学阳江校区课表学年学期

### DIFF
--- a/resources/GDOU/gdouyj.js
+++ b/resources/GDOU/gdouyj.js
@@ -203,7 +203,7 @@ async function promptUserToStart() {
     console.log("JS: 流程开始：显示公告。");
     return await window.shiguangBridgePromise.showAlert(
         "广东海洋大学阳江校区教务系统课表导入",
-        "导入前请确保您已在浏览器中成功登录广东海洋大学教务系统（jw.gdou.edu.cn）。\n本脚本将通过接口直接获取阳江校区课表，无需停留在特定页面。",
+        "请先登录广东海洋大学教务系统（jw.gdou.edu.cn），并手动打开个人课表页面。\n脚本会优先读取当前页面学年学期，读取不到时再手动选择。",
         "好的，开始导入"
     );
 }
@@ -236,6 +236,67 @@ async function selectSemester() {
  */
 function getSemesterCode(semesterIndex) {
     return semesterIndex === 0 ? "3" : "12";
+}
+
+/**
+ * 从当前页面读取当前选中的学年和学期。
+ * 不请求页面、不改变当前 URL；如果当前页面不是课表页则返回 null。
+ */
+function readCurrentPageTerm() {
+    if (typeof document === "undefined" || !document.querySelector) {
+        return null;
+    }
+
+    const yearSelect = document.querySelector("#xnm");
+    const semesterSelect = document.querySelector("#xqm");
+    if (!yearSelect || !semesterSelect) return null;
+
+    const academicYear = String(yearSelect.value || "").trim();
+    const semesterCode = String(semesterSelect.value || "").trim();
+    const semesterIndex = semesterCode === "3" ? 0 : semesterCode === "12" ? 1 : -1;
+    if (!/^\d{4}$/.test(academicYear) || semesterIndex < 0) {
+        return null;
+    }
+
+    const yearOption = yearSelect.options && yearSelect.options[yearSelect.selectedIndex];
+    const semesterOption = semesterSelect.options && semesterSelect.options[semesterSelect.selectedIndex];
+    return {
+        academicYear,
+        semesterIndex,
+        academicYearText: yearOption
+            ? String(yearOption.textContent || yearOption.innerText || "").trim() || academicYear
+            : academicYear,
+        semesterText: semesterOption
+            ? String(semesterOption.textContent || semesterOption.innerText || "").trim() || semesterCode
+            : semesterCode
+    };
+}
+
+/**
+ * 自动读取当前课表页学期，失败后保留原有手动选择流程。
+ */
+async function resolveTerm() {
+    const currentTerm = readCurrentPageTerm();
+    if (currentTerm) {
+        window.shiguangBridge.showToast(
+            `已读取当前课表页：${currentTerm.academicYearText} 第${currentTerm.semesterText}学期。`
+        );
+        return currentTerm;
+    }
+
+    window.shiguangBridge.showToast("未读取到课表页学年学期，改为手动选择。");
+    const academicYear = await getAcademicYear();
+    if (academicYear === null) return null;
+
+    const semesterIndex = await selectSemester();
+    if (semesterIndex === null || semesterIndex === -1) return null;
+
+    return {
+        academicYear: String(academicYear).trim(),
+        semesterIndex,
+        academicYearText: `${academicYear}-${Number(academicYear) + 1}`,
+        semesterText: semesterIndex === 0 ? "1" : "2"
+    };
 }
 
 /**
@@ -348,23 +409,15 @@ async function runImportFlow() {
         return;
     }
 
-    const academicYear = await getAcademicYear();
-    if (academicYear === null) {
+    const term = await resolveTerm();
+    if (term === null) {
         window.shiguangBridge.showToast("导入已取消。");
-        console.log("JS: 获取学年失败/取消，流程终止。");
+        console.log("JS: 获取学年学期失败/取消，流程终止。");
         return;
     }
-    console.log(`JS: 已选择学年: ${academicYear}`);
+    console.log(`JS: 已确定学年学期: ${term.academicYearText} 第${term.semesterText}学期`);
 
-    const semesterIndex = await selectSemester();
-    if (semesterIndex === null || semesterIndex === -1) {
-        window.shiguangBridge.showToast("导入已取消。");
-        console.log("JS: 选择学期失败/取消，流程终止。");
-        return;
-    }
-    console.log(`JS: 已选择学期索引: ${semesterIndex}`);
-
-    const result = await fetchAndParseCourses(academicYear, semesterIndex);
+    const result = await fetchAndParseCourses(term.academicYear, term.semesterIndex);
     if (result === null) {
         console.log("JS: 课程获取或解析失败，流程终止。");
         return;


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)

## PR 描述 (Description)

优化广东海洋大学阳江校区教务适配。

### 变更内容

- 在当前课表页面自动读取已选择的学年和学期。
- 当前页面无法读取或字段无效时，回退到原有的手动选择学年和学期流程。
- 课程数据继续通过广东海洋大学正方教务 API 获取。
- 保留阳江校区固定作息时间。
- 保留非慎思楼第 3～4 节使用 `10:10-11:40` 自定义时间。
- 保留手动填写开学日期，未自动推断学期开始日期。
- 不自动跳转页面，不请求其他课表页面。

### 测试情况

- 已通过拾光课程表开发者功能的自定义仓库 Beta 真机测试。
- 已验证阳江校区课程能够正常导入。
- 已验证固定阳江校区作息时间和非慎思楼第 3～4 节特殊时间。
- 已通过 Node.js 语法检查。
- 已通过自动读取当前页面学年学期和手动回退流程的模拟测试。
- 未提交账号、密码、Cookie、个人课表数据、`school_index.pb` 或 `test.js`。
