### PR TITLE
增加南京邮电大学NJUPT支持

### DIFF
--- a/index/root_index.yaml
+++ b/index/root_index.yaml
@@ -183,6 +183,11 @@ schools:
     initial: "N"
     resource_folder: "NJNU"
 
+  - id: "NJUPT"
+    name: "南京邮电大学"
+    initial: "N"
+    resource_folder: "NJUPT"
+
   - id: "XMCU"
     name: "厦门城市职业学院"
     initial: "X"

--- a/index/root_index.yaml
+++ b/index/root_index.yaml
@@ -772,6 +772,7 @@ schools:
     name: "郑州汽车工程职业学院"
     initial: "Z"
     resource_folder: "ZZVCAE"
+
   - id: "LNU"
     name: "辽宁大学"
     initial: "L"

--- a/resources/NJUPT/adapters.yaml
+++ b/resources/NJUPT/adapters.yaml
@@ -1,0 +1,8 @@
+adapters:
+  - adapter_id: "NJUPT_01"
+    adapter_name: "南京邮电大学正方教务"
+    category: "BACHELOR_AND_ASSOCIATE"
+    asset_js_path: "njupt_01.js"
+    import_url: "https://i.njupt.edu.cn/"
+    maintainer: "kemi-20"
+    description: "南京邮电大学本科正方教务课表导入。登录智慧校园并进入教务系统的个人课表查询页面，查询课表后执行导入。"

--- a/resources/NJUPT/adapters.yaml
+++ b/resources/NJUPT/adapters.yaml
@@ -1,8 +1,8 @@
 adapters:
   - adapter_id: "NJUPT_01"
-    adapter_name: "南京邮电大学正方教务"
+    adapter_name: "南京邮电大学智慧校园"
     category: "BACHELOR_AND_ASSOCIATE"
     asset_js_path: "njupt_01.js"
     import_url: "https://i.njupt.edu.cn/"
     maintainer: "kemi-20"
-    description: "南京邮电大学本科正方教务课表导入。完成 WebVPN 登录并从智慧校园打开本科教务系统后，可通过 API 导入课程、开学日期及学校作息时间。"
+    description: "南京邮电大学本科正方教务课表导入。完成 WebVPN 登录并从智慧校园打开教务系统后，可通过 API 导入课程、开学日期及学校作息时间。"

--- a/resources/NJUPT/adapters.yaml
+++ b/resources/NJUPT/adapters.yaml
@@ -5,4 +5,4 @@ adapters:
     asset_js_path: "njupt_01.js"
     import_url: "https://i.njupt.edu.cn/"
     maintainer: "kemi-20"
-    description: "南京邮电大学本科正方教务课表导入。登录智慧校园并进入教务系统的个人课表查询页面，查询课表后执行导入。"
+    description: "南京邮电大学本科正方教务课表导入。完成 WebVPN 登录，从智慧校园打开本科教务系统并进入学生课表查询页面后，可通过 API 导入课程、开学日期及学校作息时间。"

--- a/resources/NJUPT/adapters.yaml
+++ b/resources/NJUPT/adapters.yaml
@@ -5,4 +5,4 @@ adapters:
     asset_js_path: "njupt_01.js"
     import_url: "https://i.njupt.edu.cn/"
     maintainer: "kemi-20"
-    description: "南京邮电大学本科正方教务课表导入。完成 WebVPN 登录并从智慧校园打开教务系统后，可通过 API 导入课程、开学日期及学校作息时间。"
+    description: "南京邮电大学正方教务课表导入。登录后在智慧校园主页点击导入，即可通过 API 自动获取课程、开学日期及学校作息时间。"

--- a/resources/NJUPT/adapters.yaml
+++ b/resources/NJUPT/adapters.yaml
@@ -1,8 +1,8 @@
 adapters:
   - adapter_id: "NJUPT_01"
-    adapter_name: "南京邮电大学智慧校园"
+    adapter_name: "南京邮电大学正方教务"
     category: "BACHELOR_AND_ASSOCIATE"
     asset_js_path: "njupt_01.js"
     import_url: "https://i.njupt.edu.cn/"
     maintainer: "kemi-20"
-    description: "南京邮电大学正方教务课表导入。登录后在智慧校园主页点击导入，即可通过 API 自动获取课程、开学日期及学校作息时间。"
+    description: "南京邮电大学正方教务 V9 课表导入。请先登录智慧校园并进入教务系统课表页面，再点击导入；脚本将通过 API 获取学年学期、课程、开学日期及学校作息时间。"

--- a/resources/NJUPT/adapters.yaml
+++ b/resources/NJUPT/adapters.yaml
@@ -5,4 +5,4 @@ adapters:
     asset_js_path: "njupt_01.js"
     import_url: "https://i.njupt.edu.cn/"
     maintainer: "kemi-20"
-    description: "南京邮电大学本科正方教务课表导入。完成 WebVPN 登录，从智慧校园打开本科教务系统并进入学生课表查询页面后，可通过 API 导入课程、开学日期及学校作息时间。"
+    description: "南京邮电大学本科正方教务课表导入。完成 WebVPN 登录并从智慧校园打开本科教务系统后，可通过 API 导入课程、开学日期及学校作息时间。"

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -1,0 +1,261 @@
+// 基于 HTML 页面抓取的拾光课表正方适配脚本
+
+/**
+ * 解析表格
+ */
+function parserTbale() {
+    const regexName = /[●★○]/g;
+    const courseInfoList = [];
+    const $ = window.jQuery;
+    if (!$) return courseInfoList;
+
+    $('#kbgrid_table_0 td').each((i, td) => {
+        if ($(td).hasClass('td_wrap') && $(td).text().trim() !== '') {
+            const day = parseInt($(td).attr('id').split('-')[0]);
+
+            $(td).find('.timetable_con.text-left').each((i, course) => {
+                const name = $(course).find('.title font').text().replace(regexName, '').trim();
+
+                const infoStr = $(course).find('p').eq(0).find('font').eq(1).text().trim();
+
+                const position = $(course).find('p').eq(1).find('font').text().trim();
+                const teacher = $(course).find('p').eq(2).find('font').text().trim();
+
+                if (infoStr && infoStr.match(/\((\d+-\d+节)\)/) && infoStr.split('节)')[1]) {
+                    const [sections, weeks] = parserInfo(infoStr);
+
+                    if (name && position && teacher && sections.length && weeks.length) {
+                        const startSection = sections[0];
+                        const endSection = sections[sections.length - 1];
+
+                        const finalPosition = position.split(/\s+/).pop();
+
+                        const data = { name, day, weeks, teacher, position: finalPosition, startSection, endSection };
+                        courseInfoList.push(data);
+                    }
+                }
+            });
+        }
+    });
+    return courseInfoList;
+}
+
+/**
+ * 解析列表
+ */
+function parserList() {
+    const regexName = /[●★○]/g;
+    const regexWeekNum = /周数：|周/g;
+    const regexPosition = /上课地点：/g;
+    const regexTeacher = /教师 ：/g;
+
+    const $ = window.jQuery;
+    if (!$) return [];
+
+    let courseInfoList = [];
+    $('#kblist_table tbody').each((day, tbody) => {
+        if (day > 0 && day < 8) {
+            let sections;
+            $(tbody).find('tr:not(:first-child)').each((trIndex, tr) => {
+                let name, font;
+
+                if ($(tr).find('td').length > 1) {
+                    sections = parserSections($(tr).find('td:first-child').text());
+                    name = $(tr).find('td:nth-child(2)').find('.title').text().replace(regexName, '').trim();
+                    font = $(tr).find('td:nth-child(2)').find('p font');
+                } else {
+                    name = $(tr).find('td').find('.title').text().replace(regexName, '').trim();
+                    font = $(tr).find('td').find('p font');
+                }
+
+                const weekStr = $(font[0]).text().replace(regexWeekNum, '').trim();
+                const weeks = parserWeeks(weekStr);
+
+                const positionRaw = $(font[1]).text().replace(regexPosition, '').trim();
+                const finalPosition = positionRaw.split(/\s+/).pop();
+
+                const teacher = $(font[2]).text().replace(regexTeacher, '').trim();
+
+                if (name && sections && weeks.length && teacher && finalPosition) {
+                    const startSection = sections[0];
+                    const endSection = sections[sections.length - 1];
+
+                    const data = {
+                        name,
+                        day,
+                        weeks,
+                        teacher,
+                        position: finalPosition,
+                        startSection,
+                        endSection
+                    };
+                    courseInfoList.push(data);
+                }
+            });
+        }
+    });
+    return courseInfoList;
+}
+
+/**
+ * 解析课程信息
+ */
+function parserInfo(str) {
+    const sections = parserSections(str.match(/\((\d+-\d+节)\)/)[1].replace(/节/g, ''));
+    const weekStrWithMarker = str.split('节)')[1];
+    const weeks = parserWeeks(weekStrWithMarker.replace(/周/g, '').trim());
+    return [sections, weeks];
+}
+
+/**
+ * 解析节次
+ */
+function parserSections(str) {
+    const [start, end] = str.split('-').map(Number);
+    if (isNaN(start) || isNaN(end) || start > end) return [];
+    return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+}
+
+/**
+ * 解析周次
+ */
+function parserWeeks(str) {
+    const segments = str.split(',');
+    let weeks = [];
+    const segmentRegex = /(\d+)(?:-(\d+))?\s*(\([单双]\))?/g;
+
+    for (const segment of segments) {
+        // 清理段落中的周字和多余空格
+        const cleanSegment = segment.replace(/周/g, '').trim();
+
+        // 重置正则的 lastIndex
+        segmentRegex.lastIndex = 0;
+
+        let match;
+        // 循环匹配一个段落内可能存在的所有周次定义（虽然通常只有一个）
+        while ((match = segmentRegex.exec(cleanSegment)) !== null) {
+            const start = parseInt(match[1]);
+            const end = match[2] ? parseInt(match[2]) : start;
+            const flagStr = match[3] || ''; // (单) 或 (双) 或 ""
+
+            let flag = 0;
+            if (flagStr.includes('单')) {
+                flag = 1;
+            } else if (flagStr.includes('双')) {
+                flag = 2;
+            }
+
+            for (let i = start; i <= end; i++) {
+                // 过滤单双周
+                if (flag === 1 && i % 2 !== 1) continue; // 仅保留单周
+                if (flag === 2 && i % 2 !== 0) continue; // 仅保留双周
+
+                // 防止重复添加
+                if (!weeks.includes(i)) {
+                    weeks.push(i);
+                }
+            }
+        }
+    }
+
+    // 排序并返回唯一的周次列表
+    return weeks.sort((a, b) => a - b);
+}
+
+async function scrapeAndParseCourses() {
+    window.shiguangBridge.showToast("正在检查页面并抓取课程数据...");
+    const ts = `1.登陆教务系统\n2.导航到学生课表查询页面\n3.等待课表信息加载，选择对应学年、学期，确认无误后点击【查询】\n4.确保页面上显示了课程表\n5.点击下方【一键导入】`
+    try {
+        const response = await fetch(window.location.href);
+        const text = await response.text();
+        if (!text.includes("课表查询")) {
+            console.log("页面内容检查失败！");
+            await window.shiguangBridgePromise.showAlert("导入失败", "当前页面似乎不是学生课表查询页面。请检查：\n" + ts, "确定");
+            return null;
+        }
+        const typeElement = document.querySelector('#shcPDF');
+        if (!typeElement) {
+             console.log("未能找到视图类型元素 (#shcPDF)");
+             await window.shiguangBridgePromise.showAlert("导入失败", "未能识别课表视图类型，请确认您已点击查询且课表已加载完毕。", "确定");
+             return null;
+        }
+        const type = typeElement.dataset['type'];
+        const tableElement = document.querySelector(type === 'list' ? '#kblist_table' : '#kbgrid_table_0');
+        if (!tableElement) {
+             console.log("未能找到课表主体 HTML");
+             await window.shiguangBridgePromise.showAlert("导入失败", `未能找到课表主体 (${type} 视图)，请确认您已点击查询且课表已加载完毕。`, "确定");
+             return null;
+        }
+        let result = [];
+        if (type === 'list') {
+            result = parserList();
+        } else {
+            result = parserTbale();
+        }
+        if (result.length === 0) {
+            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
+            return null;
+        }
+        console.log(`JS: 课程数据解析成功，共找到 ${result.length} 门课程。`);
+        return { courses: result };
+    } catch (error) {
+        window.shiguangBridge.showToast(`抓取或解析失败: ${error.message}`);
+        console.error('JS: Scrape/Parse Error:', error);
+        await window.shiguangBridgePromise.showAlert("抓取或解析失败", `发生错误：${error.message}。请重试或联系开发者。`, "确定");
+        return null;
+    }
+}
+
+async function saveCourses(parsedCourses) {
+    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
+    console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
+    try {
+        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
+        console.log("JS: 课程保存成功！");
+        return true;
+    } catch (error) {
+        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
+        console.error('JS: Save Courses Error:', error);
+        return false;
+    }
+}
+
+
+async function runImportFlow() {
+    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
+        "教务系统课表导入",
+        "导入前请确保您已在浏览器中成功登录教务系统，并处于课表查询页面且已点击查询。",
+        "好的，开始导入"
+    );
+    if (!alertConfirmed) {
+        window.shiguangBridge.showToast("用户取消了导入。");
+        return;
+    }
+
+    if (typeof window.jQuery === 'undefined' && typeof $ === 'undefined') {
+        const errorMsg = "当前教务系统页面似乎没有加载 jQuery 库。本脚本依赖 jQuery 进行 DOM 解析。";
+        window.shiguangBridge.showToast(errorMsg);
+        await window.shiguangBridgePromise.showAlert("导入失败", errorMsg + "\n请尝试刷新页面或使用其他导入方式。", "确定");
+        console.error("JS: 缺少 jQuery 依赖，流程终止。");
+        return;
+    }
+
+    const result = await scrapeAndParseCourses();
+    if (result === null) {
+        console.log("JS: 课程获取或解析失败，流程终止。");
+        return;
+    }
+    const { courses } = result;
+
+    const saveResult = await saveCourses(courses);
+    if (!saveResult) {
+        console.log("JS: 课程保存失败，流程终止。");
+        return;
+    }
+
+    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    console.log("JS: 整个导入流程执行完毕并成功。");
+    window.shiguangBridge.notifyTaskCompletion();
+}
+
+runImportFlow();

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -200,10 +200,71 @@ function getNjuptApiBasePath() {
 }
 
 function isNjuptPortalPage() {
-    return window.location.pathname.includes("/portal");
+    return (
+        window.location.pathname.includes("/portal") ||
+        window.location.pathname.includes("/mob/home")
+    );
+}
+
+let mobileTeachingSystemSearchTriggered = false;
+
+function normalizeTeachingSystemUrl(targetUrl) {
+    if (!targetUrl) return null;
+    try {
+        const parsedUrl = new URL(targetUrl);
+        if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+            return parsedUrl.href;
+        }
+    } catch (error) {
+        console.warn("JS: 智慧校园教务入口 URL 无效：", error);
+    }
+    return null;
+}
+
+function findMobileTeachingSystemSsoUrl() {
+    if (!window.location.pathname.includes("/mob/home")) return null;
+
+    const title = document.querySelector('[title="教务系统"]');
+    const card = title?.closest(".bottom-box");
+    if (card) {
+        let capturedUrl = null;
+        const originalOpen = window.open;
+        try {
+            window.open = targetUrl => {
+                capturedUrl = targetUrl;
+                return null;
+            };
+            card.click();
+        } catch (error) {
+            console.warn("JS: 无法捕获移动端教务入口：", error);
+        } finally {
+            try {
+                window.open = originalOpen;
+            } catch (_) {}
+        }
+        return normalizeTeachingSystemUrl(capturedUrl);
+    }
+
+    if (!mobileTeachingSystemSearchTriggered) {
+        mobileTeachingSystemSearchTriggered = true;
+        const searchInput = document.querySelector('input[placeholder*="系统"]');
+        if (searchInput) {
+            searchInput.value = "教务";
+            searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+            searchInput.dispatchEvent(new KeyboardEvent("keydown", {
+                key: "Enter",
+                code: "Enter",
+                bubbles: true
+            }));
+        }
+    }
+    return null;
 }
 
 function findTeachingSystemSsoUrl() {
+    const mobileTargetUrl = findMobileTeachingSystemSsoUrl();
+    if (mobileTargetUrl) return mobileTargetUrl;
+
     const documents = [document];
     for (const iframe of document.querySelectorAll("iframe")) {
         try {
@@ -218,16 +279,8 @@ function findTeachingSystemSsoUrl() {
             const link = card.querySelector('a[title="教务系统"]');
             if (!link && !card.textContent.includes("教务系统")) continue;
 
-            const targetUrl = card.dataset.url;
-            if (!targetUrl) continue;
-            try {
-                const parsedUrl = new URL(targetUrl);
-                if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
-                    return parsedUrl.href;
-                }
-            } catch (error) {
-                console.warn("JS: portal 教务入口 URL 无效：", error);
-            }
+            const targetUrl = normalizeTeachingSystemUrl(card.dataset.url);
+            if (targetUrl) return targetUrl;
         }
     }
     return null;

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -207,6 +207,7 @@ function isNjuptPortalPage() {
 }
 
 let mobileTeachingSystemSearchTriggered = false;
+let mobileTeachingSystemExpandTriggered = false;
 
 function normalizeTeachingSystemUrl(targetUrl) {
     if (!targetUrl) return null;
@@ -243,6 +244,17 @@ function findMobileTeachingSystemSsoUrl() {
             } catch (_) {}
         }
         return normalizeTeachingSystemUrl(capturedUrl);
+    }
+
+    if (!mobileTeachingSystemExpandTriggered) {
+        const moreButton = Array.from(
+            document.querySelectorAll(".work-car .bottom-box")
+        ).find(element => element.textContent.includes("更多"));
+        if (moreButton) {
+            mobileTeachingSystemExpandTriggered = true;
+            moreButton.click();
+            return null;
+        }
     }
 
     if (!mobileTeachingSystemSearchTriggered) {

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -168,7 +168,7 @@ async function getAcademicYear() {
     const defaultYear = (now.getMonth() + 1 < 8 ? now.getFullYear() - 1 : now.getFullYear()).toString();
     return await window.shiguangBridgePromise.showPrompt(
         "选择学年",
-        "请输入学年起始年份（例如 2025-2026 学年请输入 2025）：",
+        "请输入学年起始年份（例如 2026-2027 学年请输入 2026）：",
         defaultYear,
         "validateYearInput"
     );

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -1,5 +1,21 @@
 // 基于 HTML 页面抓取的拾光课表正方适配脚本
 
+// 南京邮电大学教学活动作息时间，各校区统一、全年执行。
+const NJUPT_TIME_SLOTS = [
+    { number: 1, startTime: "08:00", endTime: "08:45" },
+    { number: 2, startTime: "08:50", endTime: "09:35" },
+    { number: 3, startTime: "09:50", endTime: "10:35" },
+    { number: 4, startTime: "10:40", endTime: "11:25" },
+    { number: 5, startTime: "11:30", endTime: "12:15" },
+    { number: 6, startTime: "13:45", endTime: "14:30" },
+    { number: 7, startTime: "14:35", endTime: "15:20" },
+    { number: 8, startTime: "15:35", endTime: "16:20" },
+    { number: 9, startTime: "16:25", endTime: "17:10" },
+    { number: 10, startTime: "18:30", endTime: "19:15" },
+    { number: 11, startTime: "19:25", endTime: "20:10" },
+    { number: 12, startTime: "20:20", endTime: "21:05" }
+];
+
 /**
  * 解析表格
  */
@@ -220,6 +236,24 @@ async function saveCourses(parsedCourses) {
     }
 }
 
+async function saveNjuptTimeSlots() {
+    window.shiguangBridge.showToast("正在保存南京邮电大学作息时间...");
+    try {
+        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(NJUPT_TIME_SLOTS));
+        console.log("JS: 南京邮电大学作息时间保存成功！");
+        return true;
+    } catch (error) {
+        window.shiguangBridge.showToast(`作息时间保存失败: ${error.message}`);
+        console.error('JS: Save NJUPT Time Slots Error:', error);
+        await window.shiguangBridgePromise.showAlert(
+            "作息时间导入失败",
+            `课程已保存，但南京邮电大学作息时间保存失败：${error.message}`,
+            "确定"
+        );
+        return false;
+    }
+}
+
 
 async function runImportFlow() {
     const alertConfirmed = await window.shiguangBridgePromise.showAlert(
@@ -253,7 +287,13 @@ async function runImportFlow() {
         return;
     }
 
-    window.shiguangBridge.showToast(`课程导入成功，共导入 ${courses.length} 门课程！`);
+    const timeSlotsSaveResult = await saveNjuptTimeSlots();
+    if (!timeSlotsSaveResult) {
+        console.log("JS: 作息时间保存失败，流程终止。");
+        return;
+    }
+
+    window.shiguangBridge.showToast(`课程及作息时间导入成功，共导入 ${courses.length} 门课程！`);
     console.log("JS: 整个导入流程执行完毕并成功。");
     window.shiguangBridge.notifyTaskCompletion();
 }

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -1,6 +1,6 @@
-// 基于 HTML 页面抓取的拾光课表正方适配脚本
+// 南京邮电大学正方教务（V9）拾光课程表适配脚本
+// 通过正方 API 获取课程与学期第一周日期，不依赖课表页面 HTML 结构。
 
-// 南京邮电大学教学活动作息时间，各校区统一、全年执行。
 const NJUPT_TIME_SLOTS = [
     { number: 1, startTime: "08:00", endTime: "08:45" },
     { number: 2, startTime: "08:50", endTime: "09:35" },
@@ -16,286 +16,291 @@ const NJUPT_TIME_SLOTS = [
     { number: 12, startTime: "20:20", endTime: "21:05" }
 ];
 
-/**
- * 解析表格
- */
-function parserTbale() {
-    const regexName = /[●★○]/g;
-    const courseInfoList = [];
-    const $ = window.jQuery;
-    if (!$) return courseInfoList;
+function mergeAndDistinctCourses(courses) {
+    if (!Array.isArray(courses) || courses.length <= 1) return courses;
 
-    $('#kbgrid_table_0 td').each((i, td) => {
-        if ($(td).hasClass('td_wrap') && $(td).text().trim() !== '') {
-            const day = parseInt($(td).attr('id').split('-')[0]);
+    const list = courses.map(course => ({
+        ...course,
+        name: course.name || "",
+        teacher: course.teacher || "",
+        position: course.position || "",
+        weeks: Array.isArray(course.weeks)
+            ? [...course.weeks].sort((a, b) => a - b)
+            : []
+    }));
 
-            $(td).find('.timetable_con.text-left').each((i, course) => {
-                const name = $(course).find('.title font').text().replace(regexName, '').trim();
+    list.sort((a, b) =>
+        a.name.localeCompare(b.name) ||
+        a.teacher.localeCompare(b.teacher) ||
+        a.position.localeCompare(b.position) ||
+        a.day - b.day ||
+        a.weeks.join(",").localeCompare(b.weeks.join(",")) ||
+        a.startSection - b.startSection
+    );
 
-                const infoStr = $(course).find('p').eq(0).find('font').eq(1).text().trim();
+    const sectionMerged = [];
+    let current = list[0];
+    for (let index = 1; index < list.length; index++) {
+        const next = list[index];
+        const sameCourseAndWeeks =
+            current.name === next.name &&
+            current.teacher === next.teacher &&
+            current.position === next.position &&
+            current.day === next.day &&
+            current.weeks.join(",") === next.weeks.join(",");
+        const continuous = current.endSection + 1 === next.startSection;
+        const duplicate =
+            current.startSection === next.startSection &&
+            current.endSection === next.endSection;
 
-                const position = $(course).find('p').eq(1).find('font').text().trim();
-                const teacher = $(course).find('p').eq(2).find('font').text().trim();
-
-                if (infoStr && infoStr.match(/\((\d+-\d+节)\)/) && infoStr.split('节)')[1]) {
-                    const [sections, weeks] = parserInfo(infoStr);
-
-                    if (name && position && teacher && sections.length && weeks.length) {
-                        const startSection = sections[0];
-                        const endSection = sections[sections.length - 1];
-
-                        const finalPosition = position.split(/\s+/).pop();
-
-                        const data = { name, day, weeks, teacher, position: finalPosition, startSection, endSection };
-                        courseInfoList.push(data);
-                    }
-                }
-            });
-        }
-    });
-    return courseInfoList;
-}
-
-/**
- * 解析列表
- */
-function parserList() {
-    const regexName = /[●★○]/g;
-    const regexWeekNum = /周数：|周/g;
-    const regexPosition = /上课地点：/g;
-    const regexTeacher = /教师 ：/g;
-
-    const $ = window.jQuery;
-    if (!$) return [];
-
-    let courseInfoList = [];
-    $('#kblist_table tbody').each((day, tbody) => {
-        if (day > 0 && day < 8) {
-            let sections;
-            $(tbody).find('tr:not(:first-child)').each((trIndex, tr) => {
-                let name, font;
-
-                if ($(tr).find('td').length > 1) {
-                    sections = parserSections($(tr).find('td:first-child').text());
-                    name = $(tr).find('td:nth-child(2)').find('.title').text().replace(regexName, '').trim();
-                    font = $(tr).find('td:nth-child(2)').find('p font');
-                } else {
-                    name = $(tr).find('td').find('.title').text().replace(regexName, '').trim();
-                    font = $(tr).find('td').find('p font');
-                }
-
-                const weekStr = $(font[0]).text().replace(regexWeekNum, '').trim();
-                const weeks = parserWeeks(weekStr);
-
-                const positionRaw = $(font[1]).text().replace(regexPosition, '').trim();
-                const finalPosition = positionRaw.split(/\s+/).pop();
-
-                const teacher = $(font[2]).text().replace(regexTeacher, '').trim();
-
-                if (name && sections && weeks.length && teacher && finalPosition) {
-                    const startSection = sections[0];
-                    const endSection = sections[sections.length - 1];
-
-                    const data = {
-                        name,
-                        day,
-                        weeks,
-                        teacher,
-                        position: finalPosition,
-                        startSection,
-                        endSection
-                    };
-                    courseInfoList.push(data);
-                }
-            });
-        }
-    });
-    return courseInfoList;
-}
-
-/**
- * 解析课程信息
- */
-function parserInfo(str) {
-    const sections = parserSections(str.match(/\((\d+-\d+节)\)/)[1].replace(/节/g, ''));
-    const weekStrWithMarker = str.split('节)')[1];
-    const weeks = parserWeeks(weekStrWithMarker.replace(/周/g, '').trim());
-    return [sections, weeks];
-}
-
-/**
- * 解析节次
- */
-function parserSections(str) {
-    const [start, end] = str.split('-').map(Number);
-    if (isNaN(start) || isNaN(end) || start > end) return [];
-    return Array.from({ length: end - start + 1 }, (_, i) => start + i);
-}
-
-/**
- * 解析周次
- */
-function parserWeeks(str) {
-    const segments = str.split(',');
-    let weeks = [];
-    const segmentRegex = /(\d+)(?:-(\d+))?\s*(\([单双]\))?/g;
-
-    for (const segment of segments) {
-        // 清理段落中的周字和多余空格
-        const cleanSegment = segment.replace(/周/g, '').trim();
-
-        // 重置正则的 lastIndex
-        segmentRegex.lastIndex = 0;
-
-        let match;
-        // 循环匹配一个段落内可能存在的所有周次定义（虽然通常只有一个）
-        while ((match = segmentRegex.exec(cleanSegment)) !== null) {
-            const start = parseInt(match[1]);
-            const end = match[2] ? parseInt(match[2]) : start;
-            const flagStr = match[3] || ''; // (单) 或 (双) 或 ""
-
-            let flag = 0;
-            if (flagStr.includes('单')) {
-                flag = 1;
-            } else if (flagStr.includes('双')) {
-                flag = 2;
-            }
-
-            for (let i = start; i <= end; i++) {
-                // 过滤单双周
-                if (flag === 1 && i % 2 !== 1) continue; // 仅保留单周
-                if (flag === 2 && i % 2 !== 0) continue; // 仅保留双周
-
-                // 防止重复添加
-                if (!weeks.includes(i)) {
-                    weeks.push(i);
-                }
-            }
+        if (sameCourseAndWeeks && continuous) {
+            current.endSection = next.endSection;
+        } else if (!sameCourseAndWeeks || !duplicate) {
+            sectionMerged.push(current);
+            current = next;
         }
     }
+    sectionMerged.push(current);
 
-    // 排序并返回唯一的周次列表
-    return weeks.sort((a, b) => a - b);
-}
+    sectionMerged.sort((a, b) =>
+        a.name.localeCompare(b.name) ||
+        a.teacher.localeCompare(b.teacher) ||
+        a.position.localeCompare(b.position) ||
+        a.day - b.day ||
+        a.startSection - b.startSection ||
+        a.endSection - b.endSection
+    );
 
-async function scrapeAndParseCourses() {
-    window.shiguangBridge.showToast("正在检查页面并抓取课程数据...");
-    const ts = `1.登陆教务系统\n2.导航到学生课表查询页面\n3.等待课表信息加载，选择对应学年、学期，确认无误后点击【查询】\n4.确保页面上显示了课程表\n5.点击下方【一键导入】`
-    try {
-        const response = await fetch(window.location.href);
-        const text = await response.text();
-        if (!text.includes("课表查询")) {
-            console.log("页面内容检查失败！");
-            await window.shiguangBridgePromise.showAlert("导入失败", "当前页面似乎不是学生课表查询页面。请检查：\n" + ts, "确定");
-            return null;
-        }
-        const typeElement = document.querySelector('#shcPDF');
-        if (!typeElement) {
-             console.log("未能找到视图类型元素 (#shcPDF)");
-             await window.shiguangBridgePromise.showAlert("导入失败", "未能识别课表视图类型，请确认您已点击查询且课表已加载完毕。", "确定");
-             return null;
-        }
-        const type = typeElement.dataset['type'];
-        const tableElement = document.querySelector(type === 'list' ? '#kblist_table' : '#kbgrid_table_0');
-        if (!tableElement) {
-             console.log("未能找到课表主体 HTML");
-             await window.shiguangBridgePromise.showAlert("导入失败", `未能找到课表主体 (${type} 视图)，请确认您已点击查询且课表已加载完毕。`, "确定");
-             return null;
-        }
-        let result = [];
-        if (type === 'list') {
-            result = parserList();
+    const result = [];
+    let merged = sectionMerged[0];
+    for (let index = 1; index < sectionMerged.length; index++) {
+        const next = sectionMerged[index];
+        const sameCourseAndSections =
+            merged.name === next.name &&
+            merged.teacher === next.teacher &&
+            merged.position === next.position &&
+            merged.day === next.day &&
+            merged.startSection === next.startSection &&
+            merged.endSection === next.endSection;
+
+        if (sameCourseAndSections) {
+            merged.weeks = [...new Set([...merged.weeks, ...next.weeks])]
+                .sort((a, b) => a - b);
         } else {
-            result = parserTbale();
+            result.push(merged);
+            merged = next;
         }
-        if (result.length === 0) {
-            window.shiguangBridge.showToast("未找到任何课程数据，请检查所选学年学期是否正确或本学期无课。");
-            return null;
+    }
+    result.push(merged);
+    return result;
+}
+
+function parseWeeks(weekText) {
+    if (!weekText) return [];
+
+    const weeks = [];
+    for (const segment of String(weekText).split(/[，,]/)) {
+        const normalized = segment.trim().replace(/（/g, "(").replace(/）/g, ")");
+        const match = normalized.match(/(\d+)(?:-(\d+))?\s*周?/);
+        if (!match) continue;
+
+        const start = Number(match[1]);
+        const end = match[2] ? Number(match[2]) : start;
+        const oddOnly = normalized.includes("(单)");
+        const evenOnly = normalized.includes("(双)");
+
+        for (let week = start; week <= end; week++) {
+            if (oddOnly && week % 2 === 0) continue;
+            if (evenOnly && week % 2 !== 0) continue;
+            weeks.push(week);
         }
-        console.log(`JS: 课程数据解析成功，共找到 ${result.length} 门课程。`);
-        return { courses: result };
-    } catch (error) {
-        window.shiguangBridge.showToast(`抓取或解析失败: ${error.message}`);
-        console.error('JS: Scrape/Parse Error:', error);
-        await window.shiguangBridgePromise.showAlert("抓取或解析失败", `发生错误：${error.message}。请重试或联系开发者。`, "确定");
-        return null;
     }
+    return [...new Set(weeks)].sort((a, b) => a - b);
 }
 
-async function saveCourses(parsedCourses) {
-    window.shiguangBridge.showToast(`正在保存 ${parsedCourses.length} 门课程...`);
-    console.log(`JS: 尝试保存 ${parsedCourses.length} 门课程...`);
+function parseJsonData(jsonData) {
+    if (!jsonData || !Array.isArray(jsonData.kbList)) {
+        console.warn("JS: API 数据中缺少 kbList。");
+        return [];
+    }
+
+    const courses = [];
+    for (const rawCourse of jsonData.kbList) {
+        if (!rawCourse.kcmc || !rawCourse.xqj || !rawCourse.jcs || !rawCourse.zcd) {
+            continue;
+        }
+
+        const weeks = parseWeeks(rawCourse.zcd);
+        const sectionNumbers = String(rawCourse.jcs).match(/\d+/g)?.map(Number) || [];
+        const day = Number(rawCourse.xqj);
+        const startSection = sectionNumbers[0];
+        const endSection = sectionNumbers[sectionNumbers.length - 1];
+
+        if (
+            weeks.length === 0 ||
+            !Number.isInteger(day) || day < 1 || day > 7 ||
+            !Number.isInteger(startSection) || !Number.isInteger(endSection) ||
+            startSection < 1 || startSection > endSection
+        ) {
+            continue;
+        }
+
+        courses.push({
+            name: String(rawCourse.kcmc).trim(),
+            teacher: String(rawCourse.xm || "").trim(),
+            position: String(rawCourse.cdmc || "").trim(),
+            day,
+            startSection,
+            endSection,
+            weeks
+        });
+    }
+
+    return mergeAndDistinctCourses(courses);
+}
+
+function validateYearInput(input) {
+    return /^\d{4}$/.test(input) ? false : "请输入四位数字的学年！";
+}
+
+async function getAcademicYear() {
+    const now = new Date();
+    const defaultYear = (now.getMonth() + 1 < 8 ? now.getFullYear() - 1 : now.getFullYear()).toString();
+    return await window.shiguangBridgePromise.showPrompt(
+        "选择学年",
+        "请输入学年起始年份（例如 2025-2026 学年请输入 2025）：",
+        defaultYear,
+        "validateYearInput"
+    );
+}
+
+async function selectSemester() {
+    return await window.shiguangBridgePromise.showSingleSelection(
+        "选择学期",
+        JSON.stringify(["第一学期", "第二学期"]),
+        0
+    );
+}
+
+function getSemesterCode(semesterIndex) {
+    return semesterIndex === 0 ? "3" : "12";
+}
+
+function getWebVpnAppBaseUrl() {
+    const marker = "/kbcx/";
+    const markerIndex = window.location.pathname.indexOf(marker);
+    if (markerIndex < 0) return null;
+    return `${window.location.origin}${window.location.pathname.slice(0, markerIndex)}`;
+}
+
+async function postForm(url, requestBody) {
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest"
+        },
+        body: requestBody,
+        credentials: "include"
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return response;
+}
+
+async function fetchSemesterStartDate(appBaseUrl, academicYear, semesterCode) {
+    const url = `${appBaseUrl}/kbcx/xskbcxZccx_cxZcByXnxq.html?gnmkdm=N2154`;
     try {
-        await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(parsedCourses, null, 2));
-        console.log("JS: 课程保存成功！");
-        return true;
+        const response = await postForm(url, `xnm=${academicYear}&xqm=${semesterCode}`);
+        const data = await response.json();
+        if (!Array.isArray(data) || data.length === 0) return null;
+
+        const firstWeek = data.find(item => String(item.zs) === "1" || String(item.zsmc) === "1") || data[0];
+        if (firstWeek.rq) {
+            const date = String(firstWeek.rq).split("/")[0];
+            if (/^\d{4}-\d{2}-\d{2}$/.test(date)) return date;
+        }
+        if (firstWeek.zcrq) {
+            const match = String(firstWeek.zcrq).match(/\d{4}-\d{2}-\d{2}/);
+            if (match) return match[0];
+        }
     } catch (error) {
-        window.shiguangBridge.showToast(`课程保存失败: ${error.message}`);
-        console.error('JS: Save Courses Error:', error);
-        return false;
+        console.error("JS: 获取开学日期失败：", error);
     }
+    return null;
 }
 
-async function saveNjuptTimeSlots() {
-    window.shiguangBridge.showToast("正在保存南京邮电大学作息时间...");
-    try {
-        await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(NJUPT_TIME_SLOTS));
-        console.log("JS: 南京邮电大学作息时间保存成功！");
-        return true;
-    } catch (error) {
-        window.shiguangBridge.showToast(`作息时间保存失败: ${error.message}`);
-        console.error('JS: Save NJUPT Time Slots Error:', error);
-        await window.shiguangBridgePromise.showAlert(
-            "作息时间导入失败",
-            `课程已保存，但南京邮电大学作息时间保存失败：${error.message}`,
-            "确定"
-        );
-        return false;
-    }
+async function fetchCourses(appBaseUrl, academicYear, semesterCode) {
+    const url = `${appBaseUrl}/kbcx/xskbcx_cxXsgrkb.html?gnmkdm=N2151`;
+    const body = `xnm=${academicYear}&xqm=${semesterCode}&kzlx=ck&xsdm=&kclbdm=`;
+    const response = await postForm(url, body);
+    const data = await response.json();
+    return parseJsonData(data);
 }
 
+async function saveImportResult(courses, semesterStartDate) {
+    await window.shiguangBridgePromise.saveImportedCourses(JSON.stringify(courses, null, 2));
+
+    const config = { semesterTotalWeeks: 20 };
+    if (semesterStartDate) config.semesterStartDate = semesterStartDate;
+    await window.shiguangBridgePromise.saveCourseConfig(JSON.stringify(config));
+    await window.shiguangBridgePromise.savePresetTimeSlots(JSON.stringify(NJUPT_TIME_SLOTS));
+}
 
 async function runImportFlow() {
-    const alertConfirmed = await window.shiguangBridgePromise.showAlert(
-        "教务系统课表导入",
-        "导入前请确保您已在浏览器中成功登录教务系统，并处于课表查询页面且已点击查询。",
+    const confirmed = await window.shiguangBridgePromise.showAlert(
+        "南京邮电大学课表导入",
+        "请先完成 WebVPN 登录，从智慧校园手动打开本科教务系统，再进入学生课表查询页面。脚本将通过当前课表页面对应的正方 API 获取课程与开学日期。",
         "好的，开始导入"
     );
-    if (!alertConfirmed) {
-        window.shiguangBridge.showToast("用户取消了导入。");
+    if (!confirmed) return;
+
+    const appBaseUrl = getWebVpnAppBaseUrl();
+    if (!appBaseUrl) {
+        await window.shiguangBridgePromise.showAlert(
+            "尚未进入课表页面",
+            "请先完成 WebVPN 登录，从智慧校园手动打开本科教务系统，再进入学生课表查询页面；等待页面加载完成后点击一键导入。",
+            "确定"
+        );
         return;
     }
 
-    if (typeof window.jQuery === 'undefined' && typeof $ === 'undefined') {
-        const errorMsg = "当前教务系统页面似乎没有加载 jQuery 库。本脚本依赖 jQuery 进行 DOM 解析。";
-        window.shiguangBridge.showToast(errorMsg);
-        await window.shiguangBridgePromise.showAlert("导入失败", errorMsg + "\n请尝试刷新页面或使用其他导入方式。", "确定");
-        console.error("JS: 缺少 jQuery 依赖，流程终止。");
-        return;
-    }
+    const academicYear = await getAcademicYear();
+    if (academicYear === null) return;
 
-    const result = await scrapeAndParseCourses();
-    if (result === null) {
-        console.log("JS: 课程获取或解析失败，流程终止。");
-        return;
-    }
-    const { courses } = result;
+    const semesterIndex = await selectSemester();
+    if (semesterIndex === null || semesterIndex === -1) return;
 
-    const saveResult = await saveCourses(courses);
-    if (!saveResult) {
-        console.log("JS: 课程保存失败，流程终止。");
-        return;
-    }
+    const semesterCode = getSemesterCode(semesterIndex);
+    window.shiguangBridge.showToast("正在从教务系统获取课表...");
 
-    const timeSlotsSaveResult = await saveNjuptTimeSlots();
-    if (!timeSlotsSaveResult) {
-        console.log("JS: 作息时间保存失败，流程终止。");
-        return;
-    }
+    try {
+        const [courses, semesterStartDate] = await Promise.all([
+            fetchCourses(appBaseUrl, academicYear, semesterCode),
+            fetchSemesterStartDate(appBaseUrl, academicYear, semesterCode)
+        ]);
 
-    window.shiguangBridge.showToast(`课程及作息时间导入成功，共导入 ${courses.length} 门课程！`);
-    console.log("JS: 整个导入流程执行完毕并成功。");
-    window.shiguangBridge.notifyTaskCompletion();
+        if (courses.length === 0) {
+            await window.shiguangBridgePromise.showAlert(
+                "未获取到课程",
+                "请确认已登录本科教务系统，并检查所选学年、学期是否正确。",
+                "确定"
+            );
+            return;
+        }
+
+        await saveImportResult(courses, semesterStartDate);
+        const dateMessage = semesterStartDate ? `，开学日期 ${semesterStartDate}` : "";
+        window.shiguangBridge.showToast(`导入成功：${courses.length} 门课程${dateMessage}`);
+        window.shiguangBridge.notifyTaskCompletion();
+    } catch (error) {
+        console.error("JS: API 课表导入失败：", error);
+        await window.shiguangBridgePromise.showAlert(
+            "导入失败",
+            `无法从教务系统 API 获取或保存数据：${error.message}`,
+            "确定"
+        );
+    }
 }
 
 runImportFlow();

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -199,6 +199,64 @@ function getNjuptApiBasePath() {
     return "";
 }
 
+function isNjuptPortalPage() {
+    return window.location.pathname.includes("/portal");
+}
+
+function findTeachingSystemSsoUrl() {
+    const documents = [document];
+    for (const iframe of document.querySelectorAll("iframe")) {
+        try {
+            if (iframe.contentDocument) documents.push(iframe.contentDocument);
+        } catch (error) {
+            console.warn("JS: 无法读取 portal iframe：", error);
+        }
+    }
+
+    for (const currentDocument of documents) {
+        for (const card of currentDocument.querySelectorAll("li.card[data-url]")) {
+            const link = card.querySelector('a[title="教务系统"]');
+            if (!link && !card.textContent.includes("教务系统")) continue;
+
+            const targetUrl = card.dataset.url;
+            if (!targetUrl) continue;
+            try {
+                const parsedUrl = new URL(targetUrl);
+                if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+                    return parsedUrl.href;
+                }
+            } catch (error) {
+                console.warn("JS: portal 教务入口 URL 无效：", error);
+            }
+        }
+    }
+    return null;
+}
+
+async function waitForTeachingSystemSsoUrl() {
+    for (let attempt = 0; attempt < 20; attempt++) {
+        const targetUrl = findTeachingSystemSsoUrl();
+        if (targetUrl) return targetUrl;
+        await new Promise(resolve => setTimeout(resolve, 250));
+    }
+    return null;
+}
+
+async function initializeTeachingSystemFromPortal(ssoUrl) {
+    window.shiguangBridge.showToast("正在通过智慧校园连接教务系统...");
+    const response = await fetch(ssoUrl, {
+        method: "GET",
+        credentials: "include",
+        redirect: "follow"
+    });
+    if (!response.ok) throw new Error(`教务系统单点登录失败：HTTP ${response.status}`);
+
+    const finalUrl = response.url || "";
+    if (finalUrl.includes("/enlink/sso/login")) {
+        throw new Error("WebVPN 登录状态已失效，请重新登录智慧校园");
+    }
+}
+
 async function postForm(url, requestBody) {
     const response = await fetch(url, {
         method: "POST",
@@ -256,16 +314,25 @@ async function saveImportResult(courses, semesterStartDate) {
 async function runImportFlow() {
     const confirmed = await window.shiguangBridgePromise.showAlert(
         "南京邮电大学课表导入",
-        "请先完成 WebVPN 登录，再从智慧校园手动打开本科教务系统。脚本将通过当前教务页面对应的正方 API 获取课程与开学日期。",
+        "请先完成 WebVPN 登录。可以直接在智慧校园主页导入，也可以进入教务系统后导入。",
         "好的，开始导入"
     );
     if (!confirmed) return;
 
-    const appBasePath = getNjuptApiBasePath();
+    let appBasePath = getNjuptApiBasePath();
+    let teachingSystemSsoUrl = null;
+
+    if (appBasePath === null && isNjuptPortalPage()) {
+        teachingSystemSsoUrl = await waitForTeachingSystemSsoUrl();
+        if (teachingSystemSsoUrl) {
+            appBasePath = new URL(teachingSystemSsoUrl).origin;
+        }
+    }
+
     if (appBasePath === null) {
         await window.shiguangBridgePromise.showAlert(
-            "尚未进入教务系统",
-            "请先完成 WebVPN 登录，再从智慧校园手动打开本科教务系统；等待页面加载完成后点击一键导入。",
+            "无法识别当前页面",
+            "请打开南邮智慧校园主页，或从智慧校园进入教务系统后重试。",
             "确定"
         );
         return;
@@ -281,6 +348,10 @@ async function runImportFlow() {
     window.shiguangBridge.showToast("正在从教务系统获取课表...");
 
     try {
+        if (teachingSystemSsoUrl) {
+            await initializeTeachingSystemFromPortal(teachingSystemSsoUrl);
+        }
+
         const [courses, semesterStartDate] = await Promise.all([
             fetchCourses(appBasePath, academicYear, semesterCode),
             fetchSemesterStartDate(appBasePath, academicYear, semesterCode)

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -159,33 +159,6 @@ function parseJsonData(jsonData) {
     return mergeAndDistinctCourses(courses);
 }
 
-function validateYearInput(input) {
-    return /^\d{4}$/.test(input) ? false : "请输入四位数字的学年！";
-}
-
-async function getAcademicYear() {
-    const now = new Date();
-    const defaultYear = (now.getMonth() + 1 < 8 ? now.getFullYear() - 1 : now.getFullYear()).toString();
-    return await window.shiguangBridgePromise.showPrompt(
-        "选择学年",
-        "请输入学年起始年份（例如 2026-2027 学年请输入 2026）：",
-        defaultYear,
-        "validateYearInput"
-    );
-}
-
-async function selectSemester() {
-    return await window.shiguangBridgePromise.showSingleSelection(
-        "选择学期",
-        JSON.stringify(["第一学期", "第二学期"]),
-        0
-    );
-}
-
-function getSemesterCode(semesterIndex) {
-    return semesterIndex === 0 ? "3" : "12";
-}
-
 function getNjuptApiBasePath() {
     const markers = ["/kbcx/", "/xtgl/"];
     const markerIndex = markers
@@ -351,6 +324,89 @@ async function postForm(url, requestBody) {
     return response;
 }
 
+async function fetchAcademicOptions(appBasePath) {
+    const url = `${appBasePath}/kbcx/xskbcx_cxXskbcxIndex.html?gnmkdm=N2151&layout=default`;
+    try {
+        const response = await fetch(url, {
+            method: "GET",
+            credentials: "include"
+        });
+        if (!response.ok) return null;
+
+        const html = await response.text();
+        const document = new DOMParser().parseFromString(html, "text/html");
+        const allYearOptions = Array.from(document.querySelectorAll("#xnm option"))
+            .filter(option => option.value !== "")
+            .map(option => ({
+                value: option.value,
+                text: option.textContent.trim(),
+                selected: option.selected
+            }));
+        const semesterOptions = Array.from(document.querySelectorAll("#xqm option"))
+            .filter(option => option.value !== "")
+            .map(option => ({
+                value: option.value,
+                text: option.textContent.trim(),
+                selected: option.selected
+            }));
+
+        if (allYearOptions.length === 0 || semesterOptions.length === 0) return null;
+
+        const selectedYearIndex = allYearOptions.findIndex(option => option.selected);
+        const start = selectedYearIndex === -1 ? 0 : Math.max(0, selectedYearIndex - 2);
+        const end = selectedYearIndex === -1
+            ? Math.min(allYearOptions.length, 5)
+            : Math.min(allYearOptions.length, selectedYearIndex + 3);
+        const yearOptions = allYearOptions.slice(start, end);
+        const selectedSemesterIndex = semesterOptions.findIndex(option => option.selected);
+
+        return {
+            yearOptions,
+            semesterOptions,
+            defaultYearIndex: selectedYearIndex === -1 ? 0 : selectedYearIndex - start,
+            defaultSemesterIndex: selectedSemesterIndex === -1 ? 0 : selectedSemesterIndex
+        };
+    } catch (error) {
+        console.error("JS: 获取学年学期列表失败：", error);
+        return null;
+    }
+}
+
+async function selectAcademicYearAndSemester(appBasePath) {
+    const options = await fetchAcademicOptions(appBasePath);
+    if (!options) {
+        await window.shiguangBridgePromise.showAlert(
+            "无法读取学年学期",
+            "请确认已登录教务系统，并重新尝试导入。",
+            "确定"
+        );
+        return null;
+    }
+
+    const yearIndex = await window.shiguangBridgePromise.showSingleSelection(
+        "选择学年",
+        JSON.stringify(options.yearOptions.map(option => option.text)),
+        options.defaultYearIndex
+    );
+    if (yearIndex === null || yearIndex === -1 || !options.yearOptions[yearIndex]) return null;
+
+    const semesterIndex = await window.shiguangBridgePromise.showSingleSelection(
+        "选择学期",
+        JSON.stringify(options.semesterOptions.map(option => option.text)),
+        options.defaultSemesterIndex
+    );
+    if (
+        semesterIndex === null ||
+        semesterIndex === -1 ||
+        !options.semesterOptions[semesterIndex]
+    ) return null;
+
+    return {
+        academicYear: options.yearOptions[yearIndex].value,
+        semesterCode: options.semesterOptions[semesterIndex].value
+    };
+}
+
 async function fetchSemesterStartDate(appBasePath, academicYear, semesterCode) {
     const url = `${appBasePath}/kbcx/xskbcxZccx_cxZcByXnxq.html?gnmkdm=N2154`;
     try {
@@ -417,19 +473,16 @@ async function runImportFlow() {
         return;
     }
 
-    const academicYear = await getAcademicYear();
-    if (academicYear === null) return;
-
-    const semesterIndex = await selectSemester();
-    if (semesterIndex === null || semesterIndex === -1) return;
-
-    const semesterCode = getSemesterCode(semesterIndex);
-    window.shiguangBridge.showToast("正在从教务系统获取课表...");
-
     try {
         if (teachingSystemSsoUrl) {
             await initializeTeachingSystemFromPortal(teachingSystemSsoUrl);
         }
+
+        const selection = await selectAcademicYearAndSemester(appBasePath);
+        if (!selection) return;
+
+        const { academicYear, semesterCode } = selection;
+        window.shiguangBridge.showToast("正在从教务系统获取课表...");
 
         const [courses, semesterStartDate] = await Promise.all([
             fetchCourses(appBasePath, academicYear, semesterCode),
@@ -439,7 +492,7 @@ async function runImportFlow() {
         if (courses.length === 0) {
             await window.shiguangBridgePromise.showAlert(
                 "未获取到课程",
-                "请确认已登录本科教务系统，并检查所选学年、学期是否正确。",
+                "请确认已登录教务系统，并检查所选学年、学期是否正确。",
                 "确定"
             );
             return;

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -1,5 +1,5 @@
 // 南京邮电大学正方教务（V9）拾光课程表适配脚本
-// 通过正方 API 获取课程与学期第一周日期，不依赖课表页面 HTML 结构。
+// 通过正方 API 获取课程与学期第一周日期
 
 const NJUPT_TIME_SLOTS = [
     { number: 1, startTime: "08:00", endTime: "08:45" },
@@ -160,153 +160,13 @@ function parseJsonData(jsonData) {
 }
 
 function getNjuptApiBasePath() {
-    const markers = ["/kbcx/", "/xtgl/"];
-    const markerIndex = markers
-        .map(marker => window.location.pathname.indexOf(marker))
-        .filter(index => index >= 0)
-        .sort((a, b) => a - b)[0];
-    if (markerIndex === undefined) return null;
+    const isTeachingSystemPage = ["/kbcx/", "/xtgl/"]
+        .some(marker => window.location.pathname.includes(marker));
+    if (!isTeachingSystemPage) return null;
 
     // 南邮 WebVPN 会拦截并改写根相对请求。若传入已经带 WebVPN
     // 哈希前缀的完整 URL，会被二次改写成“当前页面.htm/kbcx/...”。
     return "";
-}
-
-function isNjuptPortalPage() {
-    return (
-        window.location.pathname.includes("/portal") ||
-        window.location.pathname.includes("/mob/home")
-    );
-}
-
-let mobileTeachingSystemSearchTriggered = false;
-let mobileTeachingSystemExpandTriggered = false;
-let desktopTeachingSystemExpandTriggered = false;
-
-function normalizeTeachingSystemUrl(targetUrl) {
-    if (!targetUrl) return null;
-    try {
-        const parsedUrl = new URL(targetUrl);
-        if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
-            return parsedUrl.href;
-        }
-    } catch (error) {
-        console.warn("JS: 智慧校园教务入口 URL 无效：", error);
-    }
-    return null;
-}
-
-function findMobileTeachingSystemSsoUrl() {
-    if (!window.location.pathname.includes("/mob/home")) return null;
-
-    const title = document.querySelector('[title="教务系统"]');
-    const card = title?.closest(".bottom-box");
-    if (card) {
-        let capturedUrl = null;
-        const originalOpen = window.open;
-        try {
-            window.open = targetUrl => {
-                capturedUrl = targetUrl;
-                return null;
-            };
-            card.click();
-        } catch (error) {
-            console.warn("JS: 无法捕获移动端教务入口：", error);
-        } finally {
-            try {
-                window.open = originalOpen;
-            } catch (_) {}
-        }
-        return normalizeTeachingSystemUrl(capturedUrl);
-    }
-
-    if (!mobileTeachingSystemExpandTriggered) {
-        const moreButton = Array.from(
-            document.querySelectorAll(".work-car .bottom-box")
-        ).find(element => element.textContent.includes("更多"));
-        if (moreButton) {
-            mobileTeachingSystemExpandTriggered = true;
-            moreButton.click();
-            return null;
-        }
-    }
-
-    if (!mobileTeachingSystemSearchTriggered) {
-        mobileTeachingSystemSearchTriggered = true;
-        const searchInput = document.querySelector('input[placeholder*="系统"]');
-        if (searchInput) {
-            searchInput.value = "教务";
-            searchInput.dispatchEvent(new Event("input", { bubbles: true }));
-            searchInput.dispatchEvent(new KeyboardEvent("keydown", {
-                key: "Enter",
-                code: "Enter",
-                bubbles: true
-            }));
-        }
-    }
-    return null;
-}
-
-function findTeachingSystemSsoUrl() {
-    const mobileTargetUrl = findMobileTeachingSystemSsoUrl();
-    if (mobileTargetUrl) return mobileTargetUrl;
-
-    const documents = [document];
-    for (const iframe of document.querySelectorAll("iframe")) {
-        try {
-            if (iframe.contentDocument) documents.push(iframe.contentDocument);
-        } catch (error) {
-            console.warn("JS: 无法读取 portal iframe：", error);
-        }
-    }
-
-    for (const currentDocument of documents) {
-        for (const card of currentDocument.querySelectorAll("li.card[data-url]")) {
-            const link = card.querySelector('a[title="教务系统"]');
-            if (!link && !card.textContent.includes("教务系统")) continue;
-
-            const targetUrl = normalizeTeachingSystemUrl(card.dataset.url);
-            if (targetUrl) return targetUrl;
-        }
-    }
-
-    if (!desktopTeachingSystemExpandTriggered) {
-        for (const currentDocument of documents) {
-            const moreButton = Array.from(
-                currentDocument.querySelectorAll("li.card")
-            ).find(card => !card.dataset.url && card.textContent.includes("更多"));
-            if (moreButton) {
-                desktopTeachingSystemExpandTriggered = true;
-                moreButton.click();
-                break;
-            }
-        }
-    }
-    return null;
-}
-
-async function waitForTeachingSystemSsoUrl() {
-    for (let attempt = 0; attempt < 20; attempt++) {
-        const targetUrl = findTeachingSystemSsoUrl();
-        if (targetUrl) return targetUrl;
-        await new Promise(resolve => setTimeout(resolve, 250));
-    }
-    return null;
-}
-
-async function initializeTeachingSystemFromPortal(ssoUrl) {
-    window.shiguangBridge.showToast("正在通过智慧校园连接教务系统...");
-    const response = await fetch(ssoUrl, {
-        method: "GET",
-        credentials: "include",
-        redirect: "follow"
-    });
-    if (!response.ok) throw new Error(`教务系统单点登录失败：HTTP ${response.status}`);
-
-    const finalUrl = response.url || "";
-    if (finalUrl.includes("/enlink/sso/login")) {
-        throw new Error("WebVPN 登录状态已失效，请重新登录智慧校园");
-    }
 }
 
 async function postForm(url, requestBody) {
@@ -449,35 +309,22 @@ async function saveImportResult(courses, semesterStartDate) {
 async function runImportFlow() {
     const confirmed = await window.shiguangBridgePromise.showAlert(
         "南京邮电大学课表导入",
-        "请先完成 WebVPN 登录。可以直接在智慧校园主页导入，也可以进入教务系统后导入。",
+        "请先登录智慧校园并进入教务系统，建议打开课表页面后再导入。",
         "好的，开始导入"
     );
     if (!confirmed) return;
 
-    let appBasePath = getNjuptApiBasePath();
-    let teachingSystemSsoUrl = null;
-
-    if (appBasePath === null && isNjuptPortalPage()) {
-        teachingSystemSsoUrl = await waitForTeachingSystemSsoUrl();
-        if (teachingSystemSsoUrl) {
-            appBasePath = new URL(teachingSystemSsoUrl).origin;
-        }
-    }
-
+    const appBasePath = getNjuptApiBasePath();
     if (appBasePath === null) {
         await window.shiguangBridgePromise.showAlert(
             "无法识别当前页面",
-            "请打开南邮智慧校园主页，或从智慧校园进入教务系统后重试。",
+            "请先从智慧校园进入教务系统，并打开课表页面后重试。",
             "确定"
         );
         return;
     }
 
     try {
-        if (teachingSystemSsoUrl) {
-            await initializeTeachingSystemFromPortal(teachingSystemSsoUrl);
-        }
-
         const selection = await selectAcademicYearAndSemester(appBasePath);
         if (!selection) return;
 

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -208,6 +208,7 @@ function isNjuptPortalPage() {
 
 let mobileTeachingSystemSearchTriggered = false;
 let mobileTeachingSystemExpandTriggered = false;
+let desktopTeachingSystemExpandTriggered = false;
 
 function normalizeTeachingSystemUrl(targetUrl) {
     if (!targetUrl) return null;
@@ -293,6 +294,19 @@ function findTeachingSystemSsoUrl() {
 
             const targetUrl = normalizeTeachingSystemUrl(card.dataset.url);
             if (targetUrl) return targetUrl;
+        }
+    }
+
+    if (!desktopTeachingSystemExpandTriggered) {
+        for (const currentDocument of documents) {
+            const moreButton = Array.from(
+                currentDocument.querySelectorAll("li.card")
+            ).find(card => !card.dataset.url && card.textContent.includes("更多"));
+            if (moreButton) {
+                desktopTeachingSystemExpandTriggered = true;
+                moreButton.click();
+                break;
+            }
         }
     }
     return null;

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -187,9 +187,12 @@ function getSemesterCode(semesterIndex) {
 }
 
 function getWebVpnAppBaseUrl() {
-    const marker = "/kbcx/";
-    const markerIndex = window.location.pathname.indexOf(marker);
-    if (markerIndex < 0) return null;
+    const markers = ["/kbcx/", "/xtgl/"];
+    const markerIndex = markers
+        .map(marker => window.location.pathname.indexOf(marker))
+        .filter(index => index >= 0)
+        .sort((a, b) => a - b)[0];
+    if (markerIndex === undefined) return null;
     return `${window.location.origin}${window.location.pathname.slice(0, markerIndex)}`;
 }
 
@@ -250,7 +253,7 @@ async function saveImportResult(courses, semesterStartDate) {
 async function runImportFlow() {
     const confirmed = await window.shiguangBridgePromise.showAlert(
         "南京邮电大学课表导入",
-        "请先完成 WebVPN 登录，从智慧校园手动打开本科教务系统，再进入学生课表查询页面。脚本将通过当前课表页面对应的正方 API 获取课程与开学日期。",
+        "请先完成 WebVPN 登录，再从智慧校园手动打开本科教务系统。脚本将通过当前教务页面对应的正方 API 获取课程与开学日期。",
         "好的，开始导入"
     );
     if (!confirmed) return;
@@ -258,8 +261,8 @@ async function runImportFlow() {
     const appBaseUrl = getWebVpnAppBaseUrl();
     if (!appBaseUrl) {
         await window.shiguangBridgePromise.showAlert(
-            "尚未进入课表页面",
-            "请先完成 WebVPN 登录，从智慧校园手动打开本科教务系统，再进入学生课表查询页面；等待页面加载完成后点击一键导入。",
+            "尚未进入教务系统",
+            "请先完成 WebVPN 登录，再从智慧校园手动打开本科教务系统；等待页面加载完成后点击一键导入。",
             "确定"
         );
         return;

--- a/resources/NJUPT/njupt_01.js
+++ b/resources/NJUPT/njupt_01.js
@@ -186,14 +186,17 @@ function getSemesterCode(semesterIndex) {
     return semesterIndex === 0 ? "3" : "12";
 }
 
-function getWebVpnAppBaseUrl() {
+function getNjuptApiBasePath() {
     const markers = ["/kbcx/", "/xtgl/"];
     const markerIndex = markers
         .map(marker => window.location.pathname.indexOf(marker))
         .filter(index => index >= 0)
         .sort((a, b) => a - b)[0];
     if (markerIndex === undefined) return null;
-    return `${window.location.origin}${window.location.pathname.slice(0, markerIndex)}`;
+
+    // 南邮 WebVPN 会拦截并改写根相对请求。若传入已经带 WebVPN
+    // 哈希前缀的完整 URL，会被二次改写成“当前页面.htm/kbcx/...”。
+    return "";
 }
 
 async function postForm(url, requestBody) {
@@ -211,8 +214,8 @@ async function postForm(url, requestBody) {
     return response;
 }
 
-async function fetchSemesterStartDate(appBaseUrl, academicYear, semesterCode) {
-    const url = `${appBaseUrl}/kbcx/xskbcxZccx_cxZcByXnxq.html?gnmkdm=N2154`;
+async function fetchSemesterStartDate(appBasePath, academicYear, semesterCode) {
+    const url = `${appBasePath}/kbcx/xskbcxZccx_cxZcByXnxq.html?gnmkdm=N2154`;
     try {
         const response = await postForm(url, `xnm=${academicYear}&xqm=${semesterCode}`);
         const data = await response.json();
@@ -233,8 +236,8 @@ async function fetchSemesterStartDate(appBaseUrl, academicYear, semesterCode) {
     return null;
 }
 
-async function fetchCourses(appBaseUrl, academicYear, semesterCode) {
-    const url = `${appBaseUrl}/kbcx/xskbcx_cxXsgrkb.html?gnmkdm=N2151`;
+async function fetchCourses(appBasePath, academicYear, semesterCode) {
+    const url = `${appBasePath}/kbcx/xskbcx_cxXsgrkb.html?gnmkdm=N2151`;
     const body = `xnm=${academicYear}&xqm=${semesterCode}&kzlx=ck&xsdm=&kclbdm=`;
     const response = await postForm(url, body);
     const data = await response.json();
@@ -258,8 +261,8 @@ async function runImportFlow() {
     );
     if (!confirmed) return;
 
-    const appBaseUrl = getWebVpnAppBaseUrl();
-    if (!appBaseUrl) {
+    const appBasePath = getNjuptApiBasePath();
+    if (appBasePath === null) {
         await window.shiguangBridgePromise.showAlert(
             "尚未进入教务系统",
             "请先完成 WebVPN 登录，再从智慧校园手动打开本科教务系统；等待页面加载完成后点击一键导入。",
@@ -279,8 +282,8 @@ async function runImportFlow() {
 
     try {
         const [courses, semesterStartDate] = await Promise.all([
-            fetchCourses(appBaseUrl, academicYear, semesterCode),
-            fetchSemesterStartDate(appBaseUrl, academicYear, semesterCode)
+            fetchCourses(appBasePath, academicYear, semesterCode),
+            fetchSemesterStartDate(appBasePath, academicYear, semesterCode)
         ]);
 
         if (courses.length === 0) {


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)

## 适配内容

- 新增南京邮电大学（NJUPT）智慧校园教务适配
- 登录入口：https://i.njupt.edu.cn/
- 基于正方教务 V9 版本的 API 适配方案，并针对南邮智慧校园、单点登录和 WebVPN 地址改写机制进行适配
- 支持登录后直接从以下页面导入：
  - 智慧校园桌面端主页（URL 包含 `/portal`）
  - 智慧校园手机端主页（URL 包含 `/mob/home`，可自动展开隐藏应用并识别教务系统入口）
  - 教务系统主页（URL 包含 `/xtgl/`）
  - 个人课表页面（URL 包含 `/kbcx/`）
- 动态获取智慧校园中的教务系统 SSO 地址，不写死 WebVPN 哈希或教务映射前缀
- 通过正方 V9 API 自动获取课程数据和学期第一周日期
- 导入课程时自动导入南邮 12 节作息时间

## 测试情况

- 已使用南邮真实登录会话验证智慧校园到教务系统的 SSO 流程
- 2026 第一学期课程 API 和周次 API 均返回 HTTP 200
- 12 条课程均可被适配脚本正常解析，无无效记录，节次覆盖第 1—12 节
- 桌面端智慧校园主页、教务系统主页及课表页路径识别测试通过
- 手机端智慧校园主页已验证可自动展开隐藏应用并识别“教务系统”入口
- JavaScript 语法检查及本地回归测试通过
- 南邮 12 节作息时间已根据学校官方通知核对

## 修改文件

- `index/root_index.yaml`
- `resources/NJUPT/adapters.yaml`
- `resources/NJUPT/njupt_01.js`