### PR TITLE
fix: 修复广西医科大学课程星期偏移问题

### DIFF
--- a/resources/GXMU/gxmu.js
+++ b/resources/GXMU/gxmu.js
@@ -38,7 +38,7 @@ function mapCourseRecord(record) {
     const weeks = parseWeeks(record.zc || "");
     if (weeks.length === 0) return null;
 
-    const day = parseInt(record.qsxq, 10);
+    const day = parseInt(record.xq, 10);
     const startSection = parseInt(record.ps, 10);
     const endSection = parseInt(record.pe, 10);
     if (!day || day < 1 || day > 7) return null;


### PR DESCRIPTION
真实星期来自接口 xq 字段而非 qsxq，改为用 xq 映射 day，解决课表整体往后偏一天

## 目标分支确认清单 (Target Branch Checklist)  

### 本仓库已经开启main分支保护请不要提交pr到main  

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 文件已经上传,到对应的学校资源文件
* [ ] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)  


## PR 描述 (Description)

本次 PR 解决了什么问题？/ 引入了哪些新功能？(可以不填写)  
[在此处填写详细描述]