### PR TITLE
fix(LZU): 兰州大学课程列表兼容"周一"星期写法 (跟进 #609)

### DIFF
--- a/resources/LZU/lzu.js
+++ b/resources/LZU/lzu.js
@@ -156,12 +156,13 @@ function parseGridSchedule() {
 //  - 表格行结构: 课程信息行(课程号/课序号/课程名/教师...) 之后可跟 1 行或多行"排课行"
 //  - 或 div 布局: innerText 中课程信息行与排课行相邻
 // 排课字符串形如: "1-18周全周 星期一 下午56节 天山堂A504"
-const WEEK_DAY_PATTERN = /([第]?[0-9,\-，]+周(?:全周|单周|双周)?)\s*(星期[一二三四五六日天])\s*((?:上午|下午|晚上|晚)?\s*\d+(?:-\d+)?节)\s*(\S+)/;
-const WEEK_DAY_PATTERN_NO_POS = /([第]?[0-9,\-，]+周(?:全周|单周|双周)?)\s*(星期[一二三四五六日天])\s*((?:上午|下午|晚上|晚)?\s*\d+(?:-\d+)?节)/;
+const WEEK_DAY_PATTERN = /([第]?[0-9,\-，]+周(?:全周|单周|双周)?)\s*(星期[一二三四五六日天]|周[一二三四五六日天])\s*((?:上午|下午|晚上|晚)?\s*\d+(?:-\d+)?节)\s*(\S+)/;
+const WEEK_DAY_PATTERN_NO_POS = /([第]?[0-9,\-，]+周(?:全周|单周|双周)?)\s*(星期[一二三四五六日天]|周[一二三四五六日天])\s*((?:上午|下午|晚上|晚)?\s*\d+(?:-\d+)?节)/;
 const DAY_MAP = { "一": 1, "二": 2, "三": 3, "四": 4, "五": 5, "六": 6, "日": 7, "天": 7 };
 
 function dayNum(dayText) {
-    return DAY_MAP[String(dayText).replace("星期", "")] || 0;
+    // 兼容 "星期一" / "周一" / "礼拜一" / "星期天"
+    return dayFromText(dayText);
 }
 
 // 从文本片段数组中提取课程信息 (课程号 + 课程名 + 教师)
@@ -465,7 +466,7 @@ function collectProbe() {
             doc.querySelectorAll("td").forEach(cd => {
                 const t = (cd.textContent || "").trim();
                 if (/^\d{3,}[a-zA-Z]*(\(\d+\))?$/.test(t) && t.length <= 12) codeCells++;
-                if (/[0-9]+周/.test(t) && /星期[一二三四五六日天]/.test(t)) schedCells++;
+                if (/[0-9]+周/.test(t) && /(?:星期|周)[一二三四五六日天]/.test(t)) schedCells++;
             });
         } catch (e) {}
     });


### PR DESCRIPTION
## 概述
跟进 #609 的一处小修复。兰州大学教务【课程列表】视图的排课时间，星期存在"周一"（无"星期"前缀）和"星期一"两种写法，当前合并进 main 的版本仅识别"星期一"，会导致列表视图在部分页面无法导入。

## 改动
文件：`resources/LZU/lzu.js`（仅 3 处，语义与 #609 合并版本仅差此补丁）

- `WEEK_DAY_PATTERN` / `WEEK_DAY_PATTERN_NO_POS`：星期字段匹配从仅 `星期[一二三四五六日天]` 扩展为 `(星期[一二三四五六日天]|周[一二三四五六日天])`，兼容"周一"写法
- `dayNum`：改用 `dayFromText` 统一解析（支持 星期一 / 周一 / 礼拜X / 星期天）
- `collectProbe` 诊断探针的排课格统计同步兼容

## 测试情况
真机 + 兰大教务【列表视图】实测通过，约 18 条课程正确导入，网格视图不受影响。