### PR TITLE
[WIP] feat: 支持合肥工业大学 EAMS5 课表导入

### DIFF
--- a/index/root_index.yaml
+++ b/index/root_index.yaml
@@ -947,3 +947,8 @@ schools:
     name: "河南理工大学"
     initial: "H"
     resource_folder: "HPU"
+
+  - id: "HFUT"
+    name: "合肥工业大学"
+    initial: "H"
+    resource_folder: "HFUT"

--- a/resources/HFUT/adapters.yaml
+++ b/resources/HFUT/adapters.yaml
@@ -4,5 +4,5 @@ adapters:
     category: "BACHELOR_AND_ASSOCIATE"
     asset_js_path: "hfut_eams5.js"
     import_url: "https://jxglstu.hfut.edu.cn/eams5-student/login"
-    maintainer: "@Pectics"
+    maintainer: "Pectics"
     description: "登录后打开个人课表再执行导入；支持动态学期、星期一至星期日、逐周教师/教室变化及教务作息时间。"

--- a/resources/HFUT/adapters.yaml
+++ b/resources/HFUT/adapters.yaml
@@ -1,0 +1,8 @@
+adapters:
+  - adapter_id: "HFUT_01"
+    adapter_name: "翱翔门户 EAMS5 教务系统"
+    category: "BACHELOR_AND_ASSOCIATE"
+    asset_js_path: "hfut_eams5.js"
+    import_url: "https://jxglstu.hfut.edu.cn/eams5-student/login"
+    maintainer: "@Pectics"
+    description: "登录后打开个人课表再执行导入；支持动态学期、星期一至星期日、逐周教师/教室变化及教务作息时间。"

--- a/resources/HFUT/hfut_eams5.js
+++ b/resources/HFUT/hfut_eams5.js
@@ -1,0 +1,752 @@
+/**
+ * 合肥工业大学 (HFUT) - Supwisdom EAMS5 课程表导入适配器
+ *
+ * 数据来源与 EAMS5 个人课表页面一致：
+ *   1. /for-std/course-table/get-data
+ *   2. /ws/schedule-table/datum
+ *   3. /ws/schedule-table/timetable-layout
+ *
+ * 接口返回逐周排课记录，因此可以准确保留星期一至星期日、单双周、
+ * 教师/教室按周变化和非标准上课时间。接口不可用时，仅对当前页面
+ * 展示的学期启用 DOM 降级解析。
+ */
+
+(function (root, factory) {
+  "use strict";
+
+  const adapter = factory();
+  if (typeof window === "undefined" && typeof module === "object" && module.exports) {
+    module.exports = adapter;
+  } else {
+    root.runImportFlow = function () {
+      return adapter.runImportFlow(root);
+    };
+    root.runImportFlow();
+  }
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const EAMS5_CONTEXT_PATH = "/eams5-student";
+  const DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
+  const WEEKDAY_NAMES = {
+    "1": 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "一": 1,
+    "二": 2,
+    "三": 3,
+    "四": 4,
+    "五": 5,
+    "六": 6,
+    "日": 7,
+    "天": 7,
+    "MONDAY": 1,
+    "TUESDAY": 2,
+    "WEDNESDAY": 3,
+    "THURSDAY": 4,
+    "FRIDAY": 5,
+    "SATURDAY": 6,
+    "SUNDAY": 7,
+  };
+
+  function asArray(value) {
+    return Array.isArray(value) ? value : [];
+  }
+
+  function cleanText(value) {
+    if (value === null || value === undefined) return "";
+    return String(value).replace(/\s+/g, " ").trim();
+  }
+
+  function positiveInteger(value) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  function uniqueSortedNumbers(values) {
+    return Array.from(new Set(values.map(positiveInteger).filter(Boolean))).sort(function (a, b) {
+      return a - b;
+    });
+  }
+
+  function parseIsoDate(value) {
+    const match = cleanText(value).match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const timestamp = Date.UTC(year, month - 1, day);
+    const parsed = new Date(timestamp);
+    return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day
+      ? timestamp
+      : null;
+  }
+
+  function weekdayFromDate(value) {
+    const timestamp = parseIsoDate(value);
+    if (timestamp === null) return null;
+    const day = new Date(timestamp).getUTCDay();
+    return day === 0 ? 7 : day;
+  }
+
+  function weekFromDate(value, semesterStartDate) {
+    const timestamp = parseIsoDate(value);
+    const startTimestamp = parseIsoDate(semesterStartDate);
+    if (timestamp === null || startTimestamp === null || timestamp < startTimestamp) return null;
+    return Math.floor((timestamp - startTimestamp) / (7 * DAY_MILLISECONDS)) + 1;
+  }
+
+  function normalizeWeekday(value, date) {
+    const direct = WEEKDAY_NAMES[cleanText(value).toUpperCase()];
+    if (direct) return direct;
+
+    const textMatch = cleanText(value).match(/(?:星期|周)?([一二三四五六日天1-7])/);
+    if (textMatch && WEEKDAY_NAMES[textMatch[1]]) return WEEKDAY_NAMES[textMatch[1]];
+
+    return weekdayFromDate(date);
+  }
+
+  function timeToMinutes(value) {
+    if (value === null || value === undefined || value === "") return null;
+
+    const text = cleanText(value);
+    const colonMatch = text.match(/^(\d{1,2}):(\d{2})$/);
+    if (colonMatch) {
+      const hour = Number(colonMatch[1]);
+      const minute = Number(colonMatch[2]);
+      return hour <= 23 && minute <= 59 ? hour * 60 + minute : null;
+    }
+
+    if (!/^\d{3,4}$/.test(text)) return null;
+    const numeric = Number(text);
+    const hour = Math.floor(numeric / 100);
+    const minute = numeric % 100;
+    return hour <= 23 && minute <= 59 ? hour * 60 + minute : null;
+  }
+
+  function formatMinutes(minutes) {
+    if (!Number.isInteger(minutes) || minutes < 0 || minutes >= 24 * 60) return null;
+    const hour = String(Math.floor(minutes / 60)).padStart(2, "0");
+    const minute = String(minutes % 60).padStart(2, "0");
+    return hour + ":" + minute;
+  }
+
+  function normalizeCourseUnits(rawUnits) {
+    return asArray(rawUnits)
+      .map(function (unit, index) {
+        const startMinutes = timeToMinutes(unit && (unit.startTimeText || unit.startTime));
+        const endMinutes = timeToMinutes(unit && (unit.endTimeText || unit.endTime));
+        if (startMinutes === null || endMinutes === null || endMinutes <= startMinutes) return null;
+
+        return {
+          number: positiveInteger(unit.indexNo || unit.number || unit.index) || index + 1,
+          startMinutes: startMinutes,
+          endMinutes: endMinutes,
+          startTime: formatMinutes(startMinutes),
+          endTime: formatMinutes(endMinutes),
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function resolveCourseSlot(schedule, units) {
+    const startMinutes = timeToMinutes(schedule.startTimeText || schedule.startTime);
+    const endMinutes = timeToMinutes(schedule.endTimeText || schedule.endTime);
+    if (startMinutes === null || endMinutes === null || endMinutes <= startMinutes) return null;
+
+    const startIndex = units.findIndex(function (unit) {
+      return unit.startMinutes === startMinutes;
+    });
+    let endIndex = units.findIndex(function (unit) {
+      return unit.endMinutes === endMinutes;
+    });
+
+    if (startIndex >= 0 && endIndex < startIndex) {
+      const periods = positiveInteger(schedule.periods);
+      if (periods && startIndex + periods - 1 < units.length) {
+        endIndex = startIndex + periods - 1;
+      }
+    }
+
+    if (startIndex >= 0 && endIndex >= startIndex) {
+      return {
+        isCustomTime: false,
+        startSection: units[startIndex].number,
+        endSection: units[endIndex].number,
+      };
+    }
+
+    return {
+      isCustomTime: true,
+      customStartTime: formatMinutes(startMinutes),
+      customEndTime: formatMinutes(endMinutes),
+    };
+  }
+
+  function parseWeekText(value) {
+    const text = cleanText(value).replace(/第|周/g, "");
+    if (!text) return [];
+
+    const weeks = [];
+    const pieces = text.split(/[，,、;；]/);
+    pieces.forEach(function (piece) {
+      const part = piece.trim();
+      let match = part.match(/(\d+)\s*[~～\-—至]\s*(\d+)/);
+      if (match) {
+        const start = Number(match[1]);
+        const end = Number(match[2]);
+        const oddOnly = /单/.test(part);
+        const evenOnly = /双/.test(part);
+        for (let week = start; week <= end; week += 1) {
+          if ((!oddOnly || week % 2 === 1) && (!evenOnly || week % 2 === 0)) weeks.push(week);
+        }
+        return;
+      }
+
+      match = part.match(/\d+/g);
+      if (match) weeks.push.apply(weeks, match.map(Number));
+    });
+    return uniqueSortedNumbers(weeks);
+  }
+
+  function scheduleWeeks(schedule, semesterStartDate) {
+    const raw = schedule.weekIndexes || schedule.weekIndices || schedule.weekIndex;
+    let weeks = [];
+    if (Array.isArray(raw)) {
+      weeks = uniqueSortedNumbers(raw);
+    } else if (raw !== null && raw !== undefined) {
+      weeks = /^\d+$/.test(cleanText(raw))
+        ? uniqueSortedNumbers([raw])
+        : parseWeekText(raw);
+    }
+
+    if (weeks.length === 0) {
+      const derived = weekFromDate(schedule.date, semesterStartDate);
+      if (derived) weeks.push(derived);
+    }
+    return weeks;
+  }
+
+  function lessonTeachers(lesson) {
+    return Array.from(
+      new Set(
+        asArray(lesson && lesson.teacherAssignmentList)
+          .map(function (teacher) {
+            return cleanText(teacher && (teacher.name || teacher.personName));
+          })
+          .filter(Boolean)
+      )
+    ).join("、");
+  }
+
+  function scheduleTeacher(schedule, lesson) {
+    return (
+      cleanText(schedule.personName || schedule.teacherName || (schedule.teacher && schedule.teacher.name)) ||
+      lessonTeachers(lesson)
+    );
+  }
+
+  function schedulePosition(schedule) {
+    const room = schedule.room;
+    if (room && typeof room === "object") {
+      const roomName = cleanText(room.nameZh || room.name);
+      const buildingName = cleanText(room.building && (room.building.nameZh || room.building.name));
+      const campus = cleanText(
+        room.building && room.building.campus && (room.building.campus.nameZh || room.building.campus.name)
+      );
+      if (roomName) {
+        return Array.from(new Set([campus, buildingName, roomName].filter(Boolean))).join(" ");
+      }
+    }
+    return cleanText(schedule.customPlace || schedule.placeName || schedule.roomName || room);
+  }
+
+  function flagValue(flags, lessonId) {
+    if (!flags) return undefined;
+    if (typeof flags.get === "function") return flags.get(lessonId) || flags.get(String(lessonId));
+    return flags[lessonId] !== undefined ? flags[lessonId] : flags[String(lessonId)];
+  }
+
+  function isPublished(flags, lessonId) {
+    const value = flagValue(flags, lessonId);
+    if (value === undefined || value === null || value === "") return true;
+    if (typeof value === "object") {
+      return cleanText(value.flag || value.state || value.value).toLowerCase() === "publish";
+    }
+    return cleanText(value).toLowerCase() === "publish";
+  }
+
+  function courseName(schedule, lesson) {
+    return cleanText(
+      (lesson && (lesson.courseName || lesson.nameZh || lesson.name)) || schedule.courseName || schedule.lessonName
+    );
+  }
+
+  function slotSignature(slot) {
+    return slot.isCustomTime
+      ? ["custom", slot.customStartTime, slot.customEndTime]
+      : ["section", slot.startSection, slot.endSection];
+  }
+
+  function convertScheduleData(options) {
+    const lessons = asArray(options.lessonList);
+    const schedules = asArray(options.scheduleList);
+    const units = normalizeCourseUnits(options.courseUnits);
+    const lessonMap = new Map();
+    lessons.forEach(function (lesson) {
+      if (lesson && lesson.id !== undefined && lesson.id !== null) lessonMap.set(String(lesson.id), lesson);
+    });
+
+    const baseGroups = new Map();
+    schedules.forEach(function (schedule) {
+      if (!schedule || !isPublished(options.publishedFlags, schedule.lessonId)) return;
+
+      const lesson = lessonMap.get(String(schedule.lessonId)) || {};
+      const name = courseName(schedule, lesson);
+      const day = normalizeWeekday(schedule.weekday, schedule.date);
+      const weeks = scheduleWeeks(schedule, options.semesterStartDate);
+      const slot = resolveCourseSlot(schedule, units);
+      if (!name || !day || day < 1 || day > 7 || weeks.length === 0 || !slot) return;
+
+      const baseKey = JSON.stringify([
+        String(schedule.lessonId === undefined ? name : schedule.lessonId),
+        String(schedule.scheduleGroupId === undefined ? "" : schedule.scheduleGroupId),
+        day,
+      ].concat(slotSignature(slot)));
+
+      if (!baseGroups.has(baseKey)) {
+        baseGroups.set(baseKey, {
+          name: name,
+          day: day,
+          slot: slot,
+          weekDetails: new Map(),
+        });
+      }
+
+      const group = baseGroups.get(baseKey);
+      const teacher = scheduleTeacher(schedule, lesson);
+      const position = schedulePosition(schedule);
+      weeks.forEach(function (week) {
+        if (!group.weekDetails.has(week)) {
+          group.weekDetails.set(week, { teachers: new Set(), positions: new Set() });
+        }
+        const detail = group.weekDetails.get(week);
+        if (teacher) detail.teachers.add(teacher);
+        if (position) detail.positions.add(position);
+      });
+    });
+
+    const courses = [];
+    baseGroups.forEach(function (group) {
+      const detailGroups = new Map();
+      group.weekDetails.forEach(function (detail, week) {
+        const teacher = Array.from(detail.teachers).sort().join("、");
+        const position = Array.from(detail.positions).sort().join("、");
+        const detailKey = JSON.stringify([teacher, position]);
+        if (!detailGroups.has(detailKey)) detailGroups.set(detailKey, { teacher: teacher, position: position, weeks: [] });
+        detailGroups.get(detailKey).weeks.push(week);
+      });
+
+      detailGroups.forEach(function (detail) {
+        const course = {
+          name: group.name,
+          teacher: detail.teacher,
+          position: detail.position,
+          day: group.day,
+          weeks: uniqueSortedNumbers(detail.weeks),
+        };
+        if (group.slot.isCustomTime) {
+          course.isCustomTime = true;
+          course.customStartTime = group.slot.customStartTime;
+          course.customEndTime = group.slot.customEndTime;
+        } else {
+          course.startSection = group.slot.startSection;
+          course.endSection = group.slot.endSection;
+        }
+        courses.push(course);
+      });
+    });
+
+    courses.sort(function (left, right) {
+      const leftTime = left.startSection || timeToMinutes(left.customStartTime) || 0;
+      const rightTime = right.startSection || timeToMinutes(right.customStartTime) || 0;
+      return left.day - right.day || leftTime - rightTime || left.name.localeCompare(right.name, "zh-CN");
+    });
+    return courses;
+  }
+
+  function parseRenderedCardText(text, day) {
+    const normalized = String(text || "")
+      .replace(/\r/g, "")
+      .split("\n")
+      .map(cleanText)
+      .filter(Boolean);
+    if (normalized.length < 2) return null;
+
+    const name = normalized.shift();
+    const details = normalized.join(" ");
+    const match = details.match(/^(.*?)\s*\(([^()]*)周\)\s*(?:星期|周)?[一二三四五六日天1-7]?\s*\(([\d\s,，、]+)\)\s*$/);
+    if (!match) return null;
+
+    const sections = uniqueSortedNumbers(match[3].split(/[,，、\s]+/));
+    const weeks = parseWeekText(match[2]);
+    if (!name || sections.length === 0 || weeks.length === 0 || day < 1 || day > 7) return null;
+
+    return {
+      name: name,
+      teacher: "",
+      position: cleanText(match[1]),
+      day: day,
+      startSection: sections[0],
+      endSection: sections[sections.length - 1],
+      weeks: weeks,
+    };
+  }
+
+  function hasClass(element, className) {
+    return Boolean(element && element.classList && element.classList.contains(className));
+  }
+
+  function parseRenderedSchedule(documentObject) {
+    if (!documentObject || typeof documentObject.querySelectorAll !== "function") return [];
+    const columns = Array.from(
+      documentObject.querySelectorAll(".course-table .time-table-body .columns.weekday") || []
+    );
+    const courses = [];
+    columns.slice(0, 7).forEach(function (column, index) {
+      const cards = Array.from(column.children || []).filter(function (child) {
+        return hasClass(child, "card-view");
+      });
+      cards.forEach(function (card) {
+        const paragraph = card.querySelector && card.querySelector(".card-content p");
+        const course = parseRenderedCardText(paragraph && (paragraph.innerText || paragraph.textContent), index + 1);
+        if (course) courses.push(course);
+      });
+    });
+    return courses;
+  }
+
+  function renderedTimeSlots(documentObject) {
+    if (!documentObject || typeof documentObject.querySelectorAll !== "function") return [];
+    const firstColumn = Array.from(
+      documentObject.querySelectorAll(".course-table .time-table-body .columns.weekday") || []
+    )[0];
+    if (!firstColumn || typeof firstColumn.querySelectorAll !== "function") return [];
+    const units = Array.from(firstColumn.querySelectorAll(".blank-unit") || []).map(function (element) {
+      return {
+        startTime: element.getAttribute("start-time"),
+        endTime: element.getAttribute("end-time"),
+      };
+    });
+    return normalizeCourseUnits(units);
+  }
+
+  function semesterOptions(rootObject) {
+    const semesterData = asArray(rootObject.semesters);
+    const byId = new Map(
+      semesterData.map(function (semester) {
+        return [String(semester.id), semester];
+      })
+    );
+    const select = rootObject.document && rootObject.document.querySelector
+      ? rootObject.document.querySelector("#allSemesters")
+      : null;
+
+    let options = [];
+    if (select && select.options) {
+      options = Array.from(select.options).map(function (option) {
+        const data = byId.get(String(option.value)) || {};
+        return Object.assign({}, data, {
+          id: String(option.value),
+          label: cleanText(option.textContent || option.innerText || data.nameZh || data.name),
+        });
+      });
+    }
+
+    if (options.length === 0) {
+      options = semesterData.map(function (semester) {
+        return Object.assign({}, semester, {
+          id: String(semester.id),
+          label: cleanText(semester.nameZh || semester.name || semester.nameEn || semester.id),
+        });
+      });
+    }
+
+    const selectedId = cleanText(
+      (select && select.value) || (rootObject.currentSemester && rootObject.currentSemester.id) || ""
+    );
+    const defaultIndex = Math.max(0, options.findIndex(function (semester) {
+      return semester.id === selectedId;
+    }));
+    return { options: options, selectedId: selectedId, defaultIndex: defaultIndex };
+  }
+
+  function extractPageContext(rootObject) {
+    const pathname = cleanText(rootObject.location && rootObject.location.pathname);
+    const contextPath = cleanText(rootObject.CONTEXT_PATH) ||
+      (pathname.includes(EAMS5_CONTEXT_PATH) ? EAMS5_CONTEXT_PATH : "");
+    const pathStudentMatch = pathname.match(/\/course-table\/(?:info\/|semester\/\d+\/print\/)(\d+)/);
+    const studentId = positiveInteger(rootObject.studentId) || positiveInteger(pathStudentMatch && pathStudentMatch[1]);
+    const terms = semesterOptions(rootObject);
+
+    if (contextPath !== EAMS5_CONTEXT_PATH || !studentId || terms.options.length === 0) {
+      throw new Error("请先登录翱翔门户，并打开“个人课表”页面后再执行导入");
+    }
+    return {
+      contextPath: contextPath,
+      studentId: studentId,
+      semesters: terms.options,
+      selectedSemesterId: terms.selectedId,
+      defaultSemesterIndex: terms.defaultIndex,
+    };
+  }
+
+  function encodeQuery(params) {
+    return Object.keys(params)
+      .map(function (key) {
+        return encodeURIComponent(key) + "=" + encodeURIComponent(params[key]);
+      })
+      .join("&");
+  }
+
+  async function requestJson(rootObject, url, init) {
+    if (typeof rootObject.fetch !== "function") throw new Error("当前 WebView 不支持 Fetch API");
+    const response = await rootObject.fetch(url, Object.assign({ credentials: "same-origin" }, init || {}));
+    if (!response || response.ok === false) {
+      throw new Error("教务接口请求失败（HTTP " + (response && response.status ? response.status : "未知") + "）");
+    }
+
+    let payload;
+    if (typeof response.text === "function") {
+      const text = await response.text();
+      try {
+        payload = JSON.parse(text);
+      } catch (_) {
+        throw new Error("登录状态已失效，或教务接口返回了非 JSON 页面");
+      }
+    } else if (typeof response.json === "function") {
+      payload = await response.json();
+    }
+    if (!payload || typeof payload !== "object") throw new Error("教务接口没有返回有效数据");
+    return payload;
+  }
+
+  function responseBody(payload) {
+    return payload && payload.result && typeof payload.result === "object" ? payload.result : payload;
+  }
+
+  async function fetchEams5Snapshot(rootObject, pageContext, semester) {
+    const base = pageContext.contextPath;
+    const metadataPayload = await requestJson(
+      rootObject,
+      base + "/for-std/course-table/get-data?" + encodeQuery({
+        bizTypeId: 2,
+        semesterId: semester.id,
+        dataId: pageContext.studentId,
+      }),
+      { headers: { Accept: "application/json", "X-Requested-With": "XMLHttpRequest" } }
+    );
+    const metadata = responseBody(metadataPayload);
+    const lessonIds = asArray(metadata.lessonIds);
+
+    const datumPromise = lessonIds.length === 0
+      ? Promise.resolve({ result: { lessonList: asArray(metadata.lessons), scheduleList: [] } })
+      : requestJson(rootObject, base + "/ws/schedule-table/datum", {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+          },
+          body: JSON.stringify({
+            lessonIds: lessonIds,
+            studentId: pageContext.studentId,
+            weekIndex: "",
+          }),
+        });
+
+    const layoutPromise = metadata.timeTableLayoutId === null || metadata.timeTableLayoutId === undefined
+      ? Promise.resolve({ result: { courseUnitList: [] } })
+      : requestJson(rootObject, base + "/ws/schedule-table/timetable-layout", {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+          },
+          body: JSON.stringify({ timeTableLayoutId: metadata.timeTableLayoutId }),
+        });
+
+    const responses = await Promise.all([datumPromise, layoutPromise]);
+    const datum = responseBody(responses[0]);
+    const layout = responseBody(responses[1]);
+    return {
+      lessonList: asArray(datum.lessonList).length ? datum.lessonList : asArray(metadata.lessons),
+      scheduleList: asArray(datum.scheduleList),
+      courseUnits: asArray(layout.courseUnitList),
+      weekIndices: asArray(metadata.weekIndices),
+      publishedFlags: metadata.lessonId2Flag,
+    };
+  }
+
+  function mostCommon(values, fallback) {
+    const counts = new Map();
+    values.filter(function (value) {
+      return Number.isInteger(value) && value > 0;
+    }).forEach(function (value) {
+      counts.set(value, (counts.get(value) || 0) + 1);
+    });
+    let result = fallback;
+    let maxCount = -1;
+    counts.forEach(function (count, value) {
+      if (count > maxCount || (count === maxCount && value < result)) {
+        result = value;
+        maxCount = count;
+      }
+    });
+    return result;
+  }
+
+  function buildCourseConfig(semester, snapshot, courses, units) {
+    const allWeeks = asArray(snapshot.weekIndices).concat(
+      courses.reduce(function (result, course) {
+        return result.concat(course.weeks);
+      }, [])
+    );
+    let totalWeeks = Math.max.apply(null, uniqueSortedNumbers(allWeeks).concat([0]));
+    if (!totalWeeks && parseIsoDate(semester.startDate) !== null && parseIsoDate(semester.endDate) !== null) {
+      totalWeeks = Math.ceil(
+        (parseIsoDate(semester.endDate) - parseIsoDate(semester.startDate) + DAY_MILLISECONDS) /
+          (7 * DAY_MILLISECONDS)
+      );
+    }
+
+    const durations = units.map(function (unit) {
+      return unit.endMinutes - unit.startMinutes;
+    });
+    const breaks = units.slice(1).map(function (unit, index) {
+      return unit.startMinutes - units[index].endMinutes;
+    }).filter(function (minutes) {
+      return minutes > 0 && minutes <= 60;
+    });
+
+    return {
+      semesterStartDate: parseIsoDate(semester.startDate) === null ? null : semester.startDate,
+      semesterTotalWeeks: totalWeeks || 20,
+      defaultClassDuration: mostCommon(durations, 45),
+      defaultBreakDuration: mostCommon(breaks, 10),
+      firstDayOfWeek: semester.weekStartOnSunday ? 7 : 1,
+    };
+  }
+
+  async function runImportFlow(rootObject) {
+    const promiseBridge = rootObject.shiguangBridgePromise;
+    const bridge = rootObject.shiguangBridge;
+    try {
+      if (!promiseBridge || !bridge) throw new Error("拾光课程表 JS Bridge 尚未就绪");
+      const pageContext = extractPageContext(rootObject);
+      const labels = pageContext.semesters.map(function (semester) {
+        return semester.label;
+      });
+      const selected = await promiseBridge.showSingleSelection(
+        "选择学期",
+        JSON.stringify(labels),
+        pageContext.defaultSemesterIndex
+      );
+      if (selected === null || selected === undefined || Number(selected) < 0) return { cancelled: true };
+
+      const semester = pageContext.semesters[Number(selected)];
+      if (!semester) throw new Error("选择的学期无效");
+      bridge.showToast("正在读取 EAMS5 课表数据...");
+
+      let snapshot;
+      let courses;
+      let units;
+      let fallbackUsed = false;
+      try {
+        snapshot = await fetchEams5Snapshot(rootObject, pageContext, semester);
+        units = normalizeCourseUnits(snapshot.courseUnits);
+        courses = convertScheduleData({
+          lessonList: snapshot.lessonList,
+          scheduleList: snapshot.scheduleList,
+          courseUnits: snapshot.courseUnits,
+          publishedFlags: snapshot.publishedFlags,
+          semesterStartDate: semester.startDate,
+        });
+      } catch (apiError) {
+        if (semester.id !== pageContext.selectedSemesterId) throw apiError;
+        courses = parseRenderedSchedule(rootObject.document);
+        units = renderedTimeSlots(rootObject.document);
+        snapshot = { weekIndices: [] };
+        fallbackUsed = courses.length > 0;
+        if (!fallbackUsed) throw apiError;
+      }
+
+      if (courses.length === 0) {
+        throw new Error("所选学期没有可导入的已发布课程");
+      }
+
+      await promiseBridge.saveImportedCourses(JSON.stringify(courses));
+      const warnings = [];
+      if (units.length > 0) {
+        try {
+          await promiseBridge.savePresetTimeSlots(JSON.stringify(units.map(function (unit) {
+            return { number: unit.number, startTime: unit.startTime, endTime: unit.endTime };
+          })));
+        } catch (error) {
+          warnings.push("作息时间保存失败");
+        }
+      }
+
+      try {
+        const config = buildCourseConfig(semester, snapshot, courses, units);
+        await promiseBridge.saveCourseConfig(JSON.stringify(config));
+      } catch (error) {
+        warnings.push("学期配置保存失败");
+      }
+
+      if (fallbackUsed) warnings.push("接口不可用，已从当前页面导入（教师信息可能为空）");
+      const weekendCount = courses.filter(function (course) {
+        return course.day === 6 || course.day === 7;
+      }).length;
+      const warningText = warnings.length ? "\n\n注意：" + warnings.join("；") : "";
+      await promiseBridge.showAlert(
+        "导入完成",
+        "已导入 " + courses.length + " 条课程安排" +
+          (weekendCount ? "（含周末 " + weekendCount + " 条）" : "") + warningText,
+        "好的"
+      );
+      bridge.showToast("课程导入成功");
+      bridge.notifyTaskCompletion();
+      return { success: true, courses: courses, fallbackUsed: fallbackUsed, warnings: warnings };
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      if (bridge) bridge.showToast("导入失败：" + message);
+      if (promiseBridge && promiseBridge.showAlert) {
+        try {
+          await promiseBridge.showAlert("导入失败", message, "知道了");
+        } catch (_) {
+          // 用户关闭错误弹窗不应掩盖原始错误。
+        }
+      }
+      return { success: false, error: message };
+    }
+  }
+
+  return {
+    buildCourseConfig: buildCourseConfig,
+    convertScheduleData: convertScheduleData,
+    extractPageContext: extractPageContext,
+    fetchEams5Snapshot: fetchEams5Snapshot,
+    normalizeCourseUnits: normalizeCourseUnits,
+    parseRenderedCardText: parseRenderedCardText,
+    parseRenderedSchedule: parseRenderedSchedule,
+    parseWeekText: parseWeekText,
+    runImportFlow: runImportFlow,
+    timeToMinutes: timeToMinutes,
+  };
+});

--- a/resources/HFUT/hfut_eams5.js
+++ b/resources/HFUT/hfut_eams5.js
@@ -59,12 +59,24 @@
 
   function cleanText(value) {
     if (value === null || value === undefined) return "";
+    if (!["string", "number", "boolean", "bigint"].includes(typeof value)) return "";
     return String(value).replace(/\s+/g, " ").trim();
   }
 
+  function firstText(values) {
+    for (let index = 0; index < values.length; index += 1) {
+      const text = cleanText(values[index]);
+      if (text) return text;
+    }
+    return "";
+  }
+
   function positiveInteger(value) {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    if (typeof value !== "string" && typeof value !== "number") return null;
+    const text = cleanText(value);
+    if (!/^\d+$/.test(text)) return null;
+    const parsed = Number(text);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
   }
 
   function uniqueSortedNumbers(values) {
@@ -101,10 +113,11 @@
   }
 
   function normalizeWeekday(value, date) {
-    const direct = WEEKDAY_NAMES[cleanText(value).toUpperCase()];
+    const text = cleanText(value);
+    const direct = WEEKDAY_NAMES[text.toUpperCase()];
     if (direct) return direct;
 
-    const textMatch = cleanText(value).match(/(?:星期|周)?([一二三四五六日天1-7])/);
+    const textMatch = text.match(/^(?:星期|周)([一二三四五六日天1-7])$/);
     if (textMatch && WEEKDAY_NAMES[textMatch[1]]) return WEEKDAY_NAMES[textMatch[1]];
 
     return weekdayFromDate(date);
@@ -135,15 +148,27 @@
     return hour + ":" + minute;
   }
 
+  function firstTimeMinutes(values) {
+    for (let index = 0; index < values.length; index += 1) {
+      const minutes = timeToMinutes(values[index]);
+      if (minutes !== null) return minutes;
+    }
+    return null;
+  }
+
   function normalizeCourseUnits(rawUnits) {
     return asArray(rawUnits)
       .map(function (unit, index) {
-        const startMinutes = timeToMinutes(unit && (unit.startTimeText || unit.startTime));
-        const endMinutes = timeToMinutes(unit && (unit.endTimeText || unit.endTime));
+        const startMinutes = firstTimeMinutes([unit && unit.startTimeText, unit && unit.startTime]);
+        const endMinutes = firstTimeMinutes([unit && unit.endTimeText, unit && unit.endTime]);
         if (startMinutes === null || endMinutes === null || endMinutes <= startMinutes) return null;
 
         return {
-          number: positiveInteger(unit.indexNo || unit.number || unit.index) || index + 1,
+          number:
+            positiveInteger(unit && unit.indexNo) ||
+            positiveInteger(unit && unit.number) ||
+            positiveInteger(unit && unit.index) ||
+            index + 1,
           startMinutes: startMinutes,
           endMinutes: endMinutes,
           startTime: formatMinutes(startMinutes),
@@ -154,8 +179,8 @@
   }
 
   function resolveCourseSlot(schedule, units) {
-    const startMinutes = timeToMinutes(schedule.startTimeText || schedule.startTime);
-    const endMinutes = timeToMinutes(schedule.endTimeText || schedule.endTime);
+    const startMinutes = firstTimeMinutes([schedule.startTimeText, schedule.startTime]);
+    const endMinutes = firstTimeMinutes([schedule.endTimeText, schedule.endTime]);
     if (startMinutes === null || endMinutes === null || endMinutes <= startMinutes) return null;
 
     const startIndex = units.findIndex(function (unit) {
@@ -214,21 +239,33 @@
   }
 
   function scheduleWeeks(schedule, semesterStartDate) {
-    const raw = schedule.weekIndexes || schedule.weekIndices || schedule.weekIndex;
-    let weeks = [];
-    if (Array.isArray(raw)) {
-      weeks = uniqueSortedNumbers(raw);
-    } else if (raw !== null && raw !== undefined) {
-      weeks = /^\d+$/.test(cleanText(raw))
-        ? uniqueSortedNumbers([raw])
-        : parseWeekText(raw);
+    const candidates = [schedule.weekIndexes, schedule.weekIndices, schedule.weekIndex];
+    for (let index = 0; index < candidates.length; index += 1) {
+      const raw = candidates[index];
+      if (raw === null || raw === undefined || raw === "") continue;
+      const weeks = Array.isArray(raw)
+        ? uniqueSortedNumbers(raw)
+        : /^\d+$/.test(cleanText(raw))
+          ? uniqueSortedNumbers([raw])
+          : parseWeekText(raw);
+      if (weeks.length > 0) return weeks;
     }
 
-    if (weeks.length === 0) {
-      const derived = weekFromDate(schedule.date, semesterStartDate);
-      if (derived) weeks.push(derived);
-    }
-    return weeks;
+    const derived = weekFromDate(schedule.date, semesterStartDate);
+    return derived ? [derived] : [];
+  }
+
+  function teacherName(teacher) {
+    if (!teacher || typeof teacher !== "object") return cleanText(teacher);
+    return firstText([
+      teacher.nameZh,
+      teacher.name,
+      teacher.personName,
+      teacher.person && teacher.person.nameZh,
+      teacher.person && teacher.person.name,
+      teacher.teacher && teacher.teacher.nameZh,
+      teacher.teacher && teacher.teacher.name,
+    ]);
   }
 
   function lessonTeachers(lesson) {
@@ -236,7 +273,7 @@
       new Set(
         asArray(lesson && lesson.teacherAssignmentList)
           .map(function (teacher) {
-            return cleanText(teacher && (teacher.name || teacher.personName));
+            return teacherName(teacher);
           })
           .filter(Boolean)
       )
@@ -244,52 +281,75 @@
   }
 
   function scheduleTeacher(schedule, lesson) {
-    return (
-      cleanText(schedule.personName || schedule.teacherName || (schedule.teacher && schedule.teacher.name)) ||
-      lessonTeachers(lesson)
-    );
+    return firstText([schedule.personName, schedule.teacherName]) || teacherName(schedule.teacher) || lessonTeachers(lesson);
   }
 
   function schedulePosition(schedule) {
     const room = schedule.room;
     if (room && typeof room === "object") {
-      const roomName = cleanText(room.nameZh || room.name);
-      const buildingName = cleanText(room.building && (room.building.nameZh || room.building.name));
-      const campus = cleanText(
-        room.building && room.building.campus && (room.building.campus.nameZh || room.building.campus.name)
-      );
+      const roomName = firstText([room.nameZh, room.name]);
+      const buildingName = firstText([room.building && room.building.nameZh, room.building && room.building.name]);
+      const campus = firstText([
+        room.building && room.building.campus && room.building.campus.nameZh,
+        room.building && room.building.campus && room.building.campus.name,
+      ]);
       if (roomName) {
         return Array.from(new Set([campus, buildingName, roomName].filter(Boolean))).join(" ");
       }
     }
-    return cleanText(schedule.customPlace || schedule.placeName || schedule.roomName || room);
+    const roomText = typeof room === "string" ? room : "";
+    return firstText([schedule.customPlace, schedule.placeName, schedule.roomName, roomText]);
   }
 
   function flagValue(flags, lessonId) {
     if (!flags) return undefined;
-    if (typeof flags.get === "function") return flags.get(lessonId) || flags.get(String(lessonId));
+    if (typeof flags.get === "function") {
+      if (typeof flags.has === "function") {
+        if (flags.has(lessonId)) return flags.get(lessonId);
+        if (flags.has(String(lessonId))) return flags.get(String(lessonId));
+        return undefined;
+      }
+      const direct = flags.get(lessonId);
+      return direct === undefined ? flags.get(String(lessonId)) : direct;
+    }
     return flags[lessonId] !== undefined ? flags[lessonId] : flags[String(lessonId)];
   }
 
   function isPublished(flags, lessonId) {
+    if (!flags) return true;
     const value = flagValue(flags, lessonId);
-    if (value === undefined || value === null || value === "") return true;
+    if (value === undefined || value === null || value === "") return false;
     if (typeof value === "object") {
-      return cleanText(value.flag || value.state || value.value).toLowerCase() === "publish";
+      return firstText([value.flag, value.state, value.value]).toLowerCase() === "publish";
     }
     return cleanText(value).toLowerCase() === "publish";
   }
 
   function courseName(schedule, lesson) {
-    return cleanText(
-      (lesson && (lesson.courseName || lesson.nameZh || lesson.name)) || schedule.courseName || schedule.lessonName
-    );
+    return firstText([
+      lesson && lesson.courseName,
+      lesson && lesson.nameZh,
+      lesson && lesson.name,
+      schedule.courseName,
+      schedule.lessonName,
+    ]);
   }
 
   function slotSignature(slot) {
     return slot.isCustomTime
       ? ["custom", slot.customStartTime, slot.customEndTime]
       : ["section", slot.startSection, slot.endSection];
+  }
+
+  function courseStartMinutes(course, units) {
+    if (course.isCustomTime) {
+      const customStart = timeToMinutes(course.customStartTime);
+      return customStart === null ? Number.POSITIVE_INFINITY : customStart;
+    }
+    const unit = units.find(function (candidate) {
+      return candidate.number === course.startSection;
+    });
+    return unit ? unit.startMinutes : Number.POSITIVE_INFINITY;
   }
 
   function convertScheduleData(options) {
@@ -313,7 +373,7 @@
       if (!name || !day || day < 1 || day > 7 || weeks.length === 0 || !slot) return;
 
       const baseKey = JSON.stringify([
-        String(schedule.lessonId === undefined ? name : schedule.lessonId),
+        String(schedule.lessonId === undefined || schedule.lessonId === null ? name : schedule.lessonId),
         String(schedule.scheduleGroupId === undefined ? "" : schedule.scheduleGroupId),
         day,
       ].concat(slotSignature(slot)));
@@ -372,11 +432,33 @@
     });
 
     courses.sort(function (left, right) {
-      const leftTime = left.startSection || timeToMinutes(left.customStartTime) || 0;
-      const rightTime = right.startSection || timeToMinutes(right.customStartTime) || 0;
+      const leftTime = courseStartMinutes(left, units);
+      const rightTime = courseStartMinutes(right, units);
       return left.day - right.day || leftTime - rightTime || left.name.localeCompare(right.name, "zh-CN");
     });
     return courses;
+  }
+
+  function parseRenderedSections(value) {
+    const text = cleanText(value);
+    let match = text.match(/^从第\s*(\d+)\s*节开始[，,\s]*连\s*(\d+)\s*节$/);
+    if (match) {
+      const start = positiveInteger(match[1]);
+      const count = positiveInteger(match[2]);
+      return start && count ? { startSection: start, endSection: start + count - 1 } : null;
+    }
+
+    match = text.match(/^(?:第)?\s*(\d+)\s*[~～\-—至]\s*(\d+)\s*(?:节)?$/);
+    if (match) {
+      const start = positiveInteger(match[1]);
+      const end = positiveInteger(match[2]);
+      return start && end && end >= start ? { startSection: start, endSection: end } : null;
+    }
+
+    const sections = uniqueSortedNumbers(text.replace(/节/g, "").split(/[,，、\s]+/));
+    return sections.length > 0
+      ? { startSection: sections[0], endSection: sections[sections.length - 1] }
+      : null;
   }
 
   function parseRenderedCardText(text, day) {
@@ -389,20 +471,20 @@
 
     const name = normalized.shift();
     const details = normalized.join(" ");
-    const match = details.match(/^(.*?)\s*\(([^()]*)周\)\s*(?:星期|周)?[一二三四五六日天1-7]?\s*\(([\d\s,，、]+)\)\s*$/);
+    const match = details.match(/^(.*)\s*\(([^()]*)周\)\s*(?:星期|周)?[一二三四五六日天1-7]?\s*\(([^()]*)\)\s*$/);
     if (!match) return null;
 
-    const sections = uniqueSortedNumbers(match[3].split(/[,，、\s]+/));
+    const sections = parseRenderedSections(match[3]);
     const weeks = parseWeekText(match[2]);
-    if (!name || sections.length === 0 || weeks.length === 0 || day < 1 || day > 7) return null;
+    if (!name || !sections || weeks.length === 0 || day < 1 || day > 7) return null;
 
     return {
       name: name,
       teacher: "",
       position: cleanText(match[1]),
       day: day,
-      startSection: sections[0],
-      endSection: sections[sections.length - 1],
+      startSection: sections.startSection,
+      endSection: sections.endSection,
       weeks: weeks,
     };
   }
@@ -447,38 +529,38 @@
 
   function semesterOptions(rootObject) {
     const semesterData = asArray(rootObject.semesters);
-    const byId = new Map(
-      semesterData.map(function (semester) {
-        return [String(semester.id), semester];
-      })
-    );
     const select = rootObject.document && rootObject.document.querySelector
       ? rootObject.document.querySelector("#allSemesters")
       : null;
 
-    let options = [];
+    const options = [];
+    const optionIndexes = new Map();
+    semesterData.forEach(function (semester) {
+      const id = cleanText(semester && semester.id);
+      if (!id || optionIndexes.has(id)) return;
+      optionIndexes.set(id, options.length);
+      options.push(Object.assign({}, semester, {
+        id: id,
+        label: firstText([semester.nameZh, semester.name, semester.nameEn, id]),
+      }));
+    });
+
     if (select && select.options) {
-      options = Array.from(select.options).map(function (option) {
-        const data = byId.get(String(option.value)) || {};
-        return Object.assign({}, data, {
-          id: String(option.value),
-          label: cleanText(option.textContent || option.innerText || data.nameZh || data.name),
-        });
+      Array.from(select.options).forEach(function (option) {
+        const id = cleanText(option.value);
+        if (!id) return;
+        const label = firstText([option.textContent, option.innerText, id]);
+        if (optionIndexes.has(id)) {
+          const index = optionIndexes.get(id);
+          options[index] = Object.assign({}, options[index], { label: label || options[index].label });
+          return;
+        }
+        optionIndexes.set(id, options.length);
+        options.push({ id: id, label: label });
       });
     }
 
-    if (options.length === 0) {
-      options = semesterData.map(function (semester) {
-        return Object.assign({}, semester, {
-          id: String(semester.id),
-          label: cleanText(semester.nameZh || semester.name || semester.nameEn || semester.id),
-        });
-      });
-    }
-
-    const selectedId = cleanText(
-      (select && select.value) || (rootObject.currentSemester && rootObject.currentSemester.id) || ""
-    );
+    const selectedId = firstText([select && select.value, rootObject.currentSemester && rootObject.currentSemester.id]);
     const defaultIndex = Math.max(0, options.findIndex(function (semester) {
       return semester.id === selectedId;
     }));
@@ -569,6 +651,7 @@
           }),
         });
 
+    let layoutUnavailable = false;
     const layoutPromise = metadata.timeTableLayoutId === null || metadata.timeTableLayoutId === undefined
       ? Promise.resolve({ result: { courseUnitList: [] } })
       : requestJson(rootObject, base + "/ws/schedule-table/timetable-layout", {
@@ -579,6 +662,9 @@
             "X-Requested-With": "XMLHttpRequest",
           },
           body: JSON.stringify({ timeTableLayoutId: metadata.timeTableLayoutId }),
+        }).catch(function () {
+          layoutUnavailable = true;
+          return { result: { courseUnitList: [] } };
         });
 
     const responses = await Promise.all([datumPromise, layoutPromise]);
@@ -590,6 +676,7 @@
       courseUnits: asArray(layout.courseUnitList),
       weekIndices: asArray(metadata.weekIndices),
       publishedFlags: metadata.lessonId2Flag,
+      layoutUnavailable: layoutUnavailable,
     };
   }
 
@@ -618,11 +705,10 @@
       }, [])
     );
     let totalWeeks = Math.max.apply(null, uniqueSortedNumbers(allWeeks).concat([0]));
-    if (!totalWeeks && parseIsoDate(semester.startDate) !== null && parseIsoDate(semester.endDate) !== null) {
-      totalWeeks = Math.ceil(
-        (parseIsoDate(semester.endDate) - parseIsoDate(semester.startDate) + DAY_MILLISECONDS) /
-          (7 * DAY_MILLISECONDS)
-      );
+    const startTimestamp = parseIsoDate(semester.startDate);
+    const endTimestamp = parseIsoDate(semester.endDate);
+    if (!totalWeeks && startTimestamp !== null && endTimestamp !== null && endTimestamp >= startTimestamp) {
+      totalWeeks = Math.ceil((endTimestamp - startTimestamp + DAY_MILLISECONDS) / (7 * DAY_MILLISECONDS));
     }
 
     const durations = units.map(function (unit) {
@@ -635,7 +721,7 @@
     });
 
     return {
-      semesterStartDate: parseIsoDate(semester.startDate) === null ? null : semester.startDate,
+      semesterStartDate: startTimestamp === null ? null : semester.startDate,
       semesterTotalWeeks: totalWeeks || 20,
       defaultClassDuration: mostCommon(durations, 45),
       defaultBreakDuration: mostCommon(breaks, 10),
@@ -670,10 +756,13 @@
       try {
         snapshot = await fetchEams5Snapshot(rootObject, pageContext, semester);
         units = normalizeCourseUnits(snapshot.courseUnits);
+        if (units.length === 0 && semester.id === pageContext.selectedSemesterId) {
+          units = renderedTimeSlots(rootObject.document);
+        }
         courses = convertScheduleData({
           lessonList: snapshot.lessonList,
           scheduleList: snapshot.scheduleList,
-          courseUnits: snapshot.courseUnits,
+          courseUnits: units,
           publishedFlags: snapshot.publishedFlags,
           semesterStartDate: semester.startDate,
         });
@@ -686,12 +775,22 @@
         if (!fallbackUsed) throw apiError;
       }
 
+      if (courses.length === 0 && semester.id === pageContext.selectedSemesterId) {
+        const renderedCourses = parseRenderedSchedule(rootObject.document);
+        if (renderedCourses.length > 0) {
+          courses = renderedCourses;
+          if (units.length === 0) units = renderedTimeSlots(rootObject.document);
+          fallbackUsed = true;
+        }
+      }
+
       if (courses.length === 0) {
         throw new Error("所选学期没有可导入的已发布课程");
       }
 
       await promiseBridge.saveImportedCourses(JSON.stringify(courses));
       const warnings = [];
+      if (snapshot.layoutUnavailable) warnings.push("教务作息接口不可用，已按页面作息或实际时间导入");
       if (units.length > 0) {
         try {
           await promiseBridge.savePresetTimeSlots(JSON.stringify(units.map(function (unit) {

--- a/tests/hfut_eams5.test.js
+++ b/tests/hfut_eams5.test.js
@@ -19,6 +19,55 @@ const COURSE_UNITS = [
   [2110, 2155],
 ].map(([startTime, endTime]) => ({ startTime, endTime }));
 
+function jsonResponse(payload, options = {}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    ...(options.useJson
+      ? { json: async () => payload }
+      : { text: async () => options.rawText ?? JSON.stringify(payload) }),
+  };
+}
+
+function fakeCard(text) {
+  return {
+    classList: { contains: (name) => name === "card-view" },
+    querySelector: () => ({ innerText: text }),
+  };
+}
+
+function renderedDocument({ cardsByDay = {}, courseUnits = COURSE_UNITS, semesterSelect = null } = {}) {
+  const columns = Array.from({ length: 7 }, (_, index) => ({
+    children: (cardsByDay[index + 1] || []).map(fakeCard),
+    querySelectorAll: (selector) => selector === ".blank-unit"
+      ? courseUnits.map((unit) => ({
+          getAttribute: (name) => name === "start-time" ? unit.startTime : unit.endTime,
+        }))
+      : [],
+  }));
+  return {
+    querySelector: (selector) => selector === "#allSemesters" ? semesterSelect : null,
+    querySelectorAll: (selector) => selector.includes("columns.weekday") ? columns : [],
+  };
+}
+
+function addBridges(root, saved, overrides = {}) {
+  root.shiguangBridgePromise = {
+    showSingleSelection: async () => overrides.selectedIndex ?? 0,
+    saveImportedCourses: async (json) => { saved.courses = JSON.parse(json); },
+    savePresetTimeSlots: async (json) => { saved.timeSlots = JSON.parse(json); },
+    saveCourseConfig: async (json) => { saved.config = JSON.parse(json); },
+    showAlert: async (title, content) => { saved.alert = { title, content }; },
+    ...overrides.promiseBridge,
+  };
+  root.shiguangBridge = {
+    showToast: (message) => { saved.lastToast = message; },
+    notifyTaskCompletion: () => { saved.completed = true; },
+    ...overrides.bridge,
+  };
+  return root;
+}
+
 test("normalizes the twelve EAMS5 course units from the saved HFUT page format", () => {
   const units = adapter.normalizeCourseUnits(COURSE_UNITS);
   assert.equal(units.length, 12);
@@ -31,6 +80,34 @@ test("normalizes the twelve EAMS5 course units from the saved HFUT page format",
   });
   assert.equal(units[11].startTime, "21:10");
   assert.equal(units[11].endTime, "21:55");
+});
+
+test("accepts both EAMS5 time encodings and ignores malformed course units", () => {
+  assert.equal(adapter.timeToMinutes("00:00"), 0);
+  assert.equal(adapter.timeToMinutes("0805"), 485);
+  assert.equal(adapter.timeToMinutes(2110), 1270);
+  assert.equal(adapter.timeToMinutes("24:00"), null);
+  assert.equal(adapter.timeToMinutes("12:60"), null);
+  assert.equal(adapter.timeToMinutes({ value: 800 }), null);
+
+  const units = adapter.normalizeCourseUnits([
+    { indexNo: "3", startTimeText: "08:00", endTimeText: "08:45" },
+    null,
+    { number: "invalid", startTimeText: {}, startTime: 855, endTimeText: {}, endTime: 940 },
+    { index: 4, startTime: 1000, endTime: 945 },
+  ]);
+  assert.deepEqual(units.map((unit) => [unit.number, unit.startTime, unit.endTime]), [
+    [3, "08:00", "08:45"],
+    [3, "08:55", "09:40"],
+  ]);
+});
+
+test("parses ranges, odd/even weeks, individual weeks and invalid input", () => {
+  assert.deepEqual(adapter.parseWeekText("第1至7周（单周）"), [1, 3, 5, 7]);
+  assert.deepEqual(adapter.parseWeekText("2—8双周"), [2, 4, 6, 8]);
+  assert.deepEqual(adapter.parseWeekText("1、3，3；5"), [1, 3, 5]);
+  assert.deepEqual(adapter.parseWeekText("8~3周"), []);
+  assert.deepEqual(adapter.parseWeekText("无"), []);
 });
 
 test("converts per-week records and keeps Saturday, Sunday, room changes and custom times", () => {
@@ -79,6 +156,149 @@ test("converts per-week records and keeps Saturday, Sunday, room changes and cus
   assert.ok(!courses.some((course) => course.name === "未发布课程"));
 });
 
+test("normalizes weekday and week variants and derives missing values from the date", () => {
+  const courses = adapter.convertScheduleData({
+    lessonList: [],
+    courseUnits: COURSE_UNITS,
+    semesterStartDate: "2026-09-07",
+    scheduleList: [
+      {
+        lessonId: 1,
+        courseName: "周六双周课",
+        weekday: "星期六",
+        weekIndexes: [],
+        weekIndices: "2~6双周",
+        startTime: 800,
+        endTime: 845,
+      },
+      {
+        lessonId: 2,
+        lessonName: "日期推导课",
+        weekday: null,
+        weekIndex: 0,
+        date: "2026-09-13",
+        startTimeText: "10:00",
+        endTimeText: "10:45",
+      },
+      { lessonId: 3, courseName: "错误星期", weekday: "2026", weekIndex: 1, startTime: 800, endTime: 845 },
+      { lessonId: 4, courseName: "错误时间", weekday: 1, weekIndex: 1, startTime: 2500, endTime: 2600 },
+      { lessonId: 5, weekday: 1, weekIndex: 1, startTime: 800, endTime: 845 },
+    ],
+  });
+
+  assert.deepEqual(courses.map((course) => [course.name, course.day, course.weeks]), [
+    ["周六双周课", 6, [2, 4, 6]],
+    ["日期推导课", 7, [1]],
+  ]);
+});
+
+test("combines concurrent teachers and rooms without stringifying empty room objects", () => {
+  const lessonList = [
+    { id: 1, courseName: "联合授课", teacherAssignmentList: [{ person: { nameZh: "王老师" } }] },
+    { id: 2, courseName: "无地点课程" },
+    { id: 3, courseName: "字符串地点课程" },
+  ];
+  const nestedRoom = {
+    nameZh: "101",
+    building: { nameZh: "综合楼", campus: { nameZh: "翡翠湖校区" } },
+  };
+  const scheduleList = [
+    { lessonId: 1, scheduleGroupId: 1, weekday: 2, weekIndex: 1, startTime: 800, endTime: 845, personName: "张老师", room: nestedRoom },
+    { lessonId: 1, scheduleGroupId: 1, weekday: 2, weekIndex: 1, startTime: 800, endTime: 845, teacher: { nameZh: "李老师" }, room: nestedRoom },
+    { lessonId: 1, scheduleGroupId: 1, weekday: 2, weekIndex: 2, startTime: 800, endTime: 845, room: { id: 99 }, customPlace: {}, placeName: "操场" },
+    { lessonId: 2, scheduleGroupId: 2, weekday: 2, weekIndex: 1, startTime: 855, endTime: 940, room: { id: 100 } },
+    { lessonId: 3, scheduleGroupId: 3, weekday: 2, weekIndex: 1, startTime: 1000, endTime: 1045, room: "临时教室" },
+  ];
+
+  const courses = adapter.convertScheduleData({ lessonList, scheduleList, courseUnits: COURSE_UNITS });
+  const firstWeek = courses.find((course) => course.name === "联合授课" && course.weeks[0] === 1);
+  const secondWeek = courses.find((course) => course.name === "联合授课" && course.weeks[0] === 2);
+  const noLocation = courses.find((course) => course.name === "无地点课程");
+  const stringLocation = courses.find((course) => course.name === "字符串地点课程");
+  assert.deepEqual(firstWeek, {
+    name: "联合授课",
+    teacher: "张老师、李老师",
+    position: "翡翠湖校区 综合楼 101",
+    day: 2,
+    weeks: [1],
+    startSection: 1,
+    endSection: 1,
+  });
+  assert.equal(secondWeek.teacher, "王老师");
+  assert.equal(secondWeek.position, "操场");
+  assert.equal(noLocation.position, "");
+  assert.equal(stringLocation.position, "临时教室");
+  assert.ok(courses.every((course) => !course.position.includes("[object Object]")));
+});
+
+test("sorts standard sections and custom times on the same minute scale", () => {
+  const lessonList = [
+    { id: 1, courseName: "晚间标准课" },
+    { id: 2, courseName: "清晨自定义课" },
+    { id: 3, courseName: "上午标准课" },
+    { id: 4, courseName: "午间自定义课" },
+  ];
+  const scheduleList = [
+    { lessonId: 1, weekday: 1, weekIndex: 1, startTime: 1920, endTime: 2005 },
+    { lessonId: 2, weekday: 1, weekIndex: 1, startTime: 730, endTime: 745 },
+    { lessonId: 3, weekday: 1, weekIndex: 1, startTime: 800, endTime: 845 },
+    { lessonId: 4, weekday: 1, weekIndex: 1, startTime: 1200, endTime: 1230 },
+  ];
+
+  const courses = adapter.convertScheduleData({ lessonList, scheduleList, courseUnits: COURSE_UNITS });
+  assert.deepEqual(courses.map((course) => course.name), [
+    "清晨自定义课",
+    "上午标准课",
+    "午间自定义课",
+    "晚间标准课",
+  ]);
+});
+
+test("uses periods to recover a section span when the reported end time is not a unit boundary", () => {
+  const courses = adapter.convertScheduleData({
+    lessonList: [{ id: 1, courseName: "两节课" }],
+    scheduleList: [{ lessonId: 1, weekday: "MONDAY", weekIndex: "3", startTime: 800, endTime: 930, periods: 2 }],
+    courseUnits: COURSE_UNITS,
+  });
+  assert.equal(courses[0].startSection, 1);
+  assert.equal(courses[0].endSection, 2);
+  assert.equal(courses[0].isCustomTime, undefined);
+});
+
+test("supports Map and map-like publication flags without dropping falsey values", () => {
+  const base = {
+    lessonList: [
+      { id: 1, courseName: "已发布" },
+      { id: 2, courseName: "未发布" },
+      { id: 3, courseName: "缺少发布状态" },
+    ],
+    scheduleList: [
+      { lessonId: 1, weekday: 1, weekIndex: 1, startTime: 800, endTime: 845 },
+      { lessonId: 2, weekday: 1, weekIndex: 1, startTime: 855, endTime: 940 },
+      { lessonId: 3, weekday: 1, weekIndex: 1, startTime: 1000, endTime: 1045 },
+    ],
+    courseUnits: COURSE_UNITS,
+  };
+  const mapCourses = adapter.convertScheduleData({
+    ...base,
+    publishedFlags: new Map([["1", { flag: "publish" }], [2, { state: "draft" }]]),
+  });
+  assert.deepEqual(mapCourses.map((course) => course.name), ["已发布"]);
+
+  const missingFlagCourses = adapter.convertScheduleData({
+    ...base,
+    publishedFlags: { 1: "publish" },
+  });
+  assert.deepEqual(missingFlagCourses.map((course) => course.name), ["已发布"]);
+
+  const values = { 1: "publish", 2: false };
+  const mapLikeCourses = adapter.convertScheduleData({
+    ...base,
+    publishedFlags: { get: (key) => typeof key === "string" ? values[key] : undefined },
+  });
+  assert.deepEqual(mapLikeCourses.map((course) => course.name), ["已发布"]);
+});
+
 test("parses rendered EAMS5 card text without assuming weekdays only", () => {
   assert.deepEqual(
     adapter.parseRenderedCardText("数据结构\n翠八教负09* (1~8周) 7 (3,4)", 7),
@@ -95,11 +315,53 @@ test("parses rendered EAMS5 card text without assuming weekdays only", () => {
   assert.deepEqual(adapter.parseWeekText("1~15单周,2~16双周"), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 });
 
+test("parses single, ranged and multi-period EAMS5 rendered section labels", () => {
+  assert.deepEqual(
+    adapter.parseRenderedCardText("单节课\nA101 (1,3周) 星期六 (5节)", 6),
+    {
+      name: "单节课",
+      teacher: "",
+      position: "A101",
+      day: 6,
+      startSection: 5,
+      endSection: 5,
+      weeks: [1, 3],
+    }
+  );
+  assert.deepEqual(
+    adapter.parseRenderedCardText("长课\n实验室 (2~8双周) 周日 (从第 3 节开始，连 3 节)", 7),
+    {
+      name: "长课",
+      teacher: "",
+      position: "实验室",
+      day: 7,
+      startSection: 3,
+      endSection: 5,
+      weeks: [2, 4, 6, 8],
+    }
+  );
+  assert.equal(adapter.parseRenderedCardText("错误范围\nA101 (1~4周) 1 (第5至3节)", 1), null);
+});
+
+test("uses the final week group when a rendered room label contains its own week annotation", () => {
+  const course = adapter.parseRenderedCardText(
+    "轮换教室\nA101(1~4周),B202(5~8周) (1~8周) 7 (10~12节)",
+    7
+  );
+  assert.equal(course.position, "A101(1~4周),B202(5~8周)");
+  assert.deepEqual(course.weeks, [1, 2, 3, 4, 5, 6, 7, 8]);
+  assert.equal(course.startSection, 10);
+  assert.equal(course.endSection, 12);
+});
+
+test("rejects incomplete rendered cards and out-of-range weekday columns", () => {
+  assert.equal(adapter.parseRenderedCardText("只有课程名", 1), null);
+  assert.equal(adapter.parseRenderedCardText("课程\n教室 (无周次周) 1 (1,2)", 1), null);
+  assert.equal(adapter.parseRenderedCardText("课程\n教室 (1~2周) 1 (1,2)", 8), null);
+  assert.deepEqual(adapter.parseRenderedSchedule(null), []);
+});
+
 test("the rendered-page fallback scans all seven weekday columns", () => {
-  const fakeCard = (text) => ({
-    classList: { contains: (name) => name === "card-view" },
-    querySelector: () => ({ innerText: text }),
-  });
   const columns = Array.from({ length: 7 }, (_, index) => ({
     children: index === 5
       ? [fakeCard("周六课程\n翡翠湖校区 (2~4周) 6 (1,2)")]
@@ -115,6 +377,118 @@ test("the rendered-page fallback scans all seven weekday columns", () => {
   assert.deepEqual(courses.map((course) => course.day), [6, 7]);
   assert.deepEqual(courses[1].weeks, [1, 3, 5]);
   assert.equal(courses[1].endSection, 12);
+});
+
+test("keeps the global semester list when Selectize collapses the native select", () => {
+  const semesterSelect = {
+    value: "334",
+    options: [{ value: "334", textContent: "当前显示学期" }],
+  };
+  const context = adapter.extractPageContext({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: "12345",
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 334 },
+    semesters: [
+      { id: 354, nameZh: "第一学期", startDate: "2026-09-07" },
+      { id: 334, nameZh: "第二学期", startDate: "2026-03-02" },
+    ],
+    document: renderedDocument({ semesterSelect }),
+  });
+
+  assert.deepEqual(context.semesters.map((semester) => semester.id), ["354", "334"]);
+  assert.deepEqual(context.semesters.map((semester) => semester.label), ["第一学期", "当前显示学期"]);
+  assert.equal(context.selectedSemesterId, "334");
+  assert.equal(context.defaultSemesterIndex, 1);
+});
+
+test("supports DOM-only semester options and student IDs from course-table URLs", () => {
+  const semesterSelect = {
+    value: "354",
+    options: [
+      { value: "", textContent: "请选择" },
+      { value: "354", textContent: "第一学期" },
+      { value: "334", textContent: "第二学期" },
+    ],
+  };
+  const context = adapter.extractPageContext({
+    location: { pathname: "/eams5-student/for-std/course-table/semester/354/print/12345" },
+    semesters: [],
+    currentSemester: { id: 354 },
+    document: renderedDocument({ semesterSelect }),
+  });
+  assert.equal(context.studentId, 12345);
+  assert.deepEqual(context.semesters.map((semester) => semester.id), ["354", "334"]);
+  assert.throws(
+    () => adapter.extractPageContext({ location: { pathname: "/dashboard" }, semesters: [], document: {} }),
+    /个人课表/
+  );
+});
+
+test("fetches an empty-semester snapshot without unnecessary datum or layout requests", async () => {
+  const calls = [];
+  const root = {
+    fetch: async (url, init) => {
+      calls.push({ url, init });
+      return jsonResponse({
+        result: {
+          lessonIds: [],
+          lessons: [{ id: 1, courseName: "仅元数据课程" }],
+          weekIndices: [1, 2],
+        },
+      }, { useJson: true });
+    },
+  };
+  const snapshot = await adapter.fetchEams5Snapshot(
+    root,
+    { contextPath: "/eams5-student", studentId: 12345 },
+    { id: "354" }
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.credentials, "same-origin");
+  assert.equal(snapshot.lessonList[0].courseName, "仅元数据课程");
+  assert.deepEqual(snapshot.scheduleList, []);
+  assert.deepEqual(snapshot.courseUnits, []);
+  assert.equal(snapshot.layoutUnavailable, false);
+});
+
+test("keeps datum records when only the optional timetable-layout request fails", async () => {
+  const root = {
+    fetch: async (url) => {
+      if (url.includes("get-data")) {
+        return jsonResponse({ lessonIds: [1], timeTableLayoutId: 9, weekIndices: [1] });
+      }
+      if (url.includes("/datum")) {
+        return jsonResponse({ result: { lessonList: [{ id: 1, courseName: "课程" }], scheduleList: [{ lessonId: 1 }] } });
+      }
+      return jsonResponse({}, { ok: false, status: 503 });
+    },
+  };
+  const snapshot = await adapter.fetchEams5Snapshot(
+    root,
+    { contextPath: "/eams5-student", studentId: 12345 },
+    { id: "354" }
+  );
+  assert.equal(snapshot.lessonList[0].courseName, "课程");
+  assert.equal(snapshot.scheduleList.length, 1);
+  assert.deepEqual(snapshot.courseUnits, []);
+  assert.equal(snapshot.layoutUnavailable, true);
+});
+
+test("does not hide a required datum request failure", async () => {
+  const root = {
+    fetch: async (url) => url.includes("get-data")
+      ? jsonResponse({ lessonIds: [1], timeTableLayoutId: null })
+      : jsonResponse({}, { ok: false, status: 401 }),
+  };
+  await assert.rejects(
+    adapter.fetchEams5Snapshot(
+      root,
+      { contextPath: "/eams5-student", studentId: 12345 },
+      { id: "354" }
+    ),
+    /HTTP 401/
+  );
 });
 
 test("runs the complete bridge flow against mocked EAMS5 endpoints", async () => {
@@ -187,6 +561,183 @@ test("runs the complete bridge flow against mocked EAMS5 endpoints", async () =>
   assert.deepEqual(JSON.parse(requests[2].init.body), { timeTableLayoutId: 99 });
 });
 
+test("falls back to the current rendered page after an API error and saves rendered time slots", async () => {
+  const saved = {};
+  const root = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [{ id: 354, nameZh: "当前学期", startDate: "2026-09-07", endDate: "2027-01-17" }],
+    document: renderedDocument({
+      cardsByDay: { 7: ["周日课程\n实验楼 (1~3周) 7 (1,2)"] },
+    }),
+    fetch: async () => jsonResponse({}, { ok: false, status: 500 }),
+  }, saved);
+
+  const result = await adapter.runImportFlow(root);
+  assert.equal(result.success, true);
+  assert.equal(result.fallbackUsed, true);
+  assert.equal(saved.courses[0].day, 7);
+  assert.equal(saved.courses[0].teacher, "");
+  assert.equal(saved.timeSlots.length, 12);
+  assert.match(saved.alert.content, /教师信息可能为空/);
+  assert.equal(saved.completed, true);
+});
+
+test("falls back when the current-semester API succeeds but yields no course records", async () => {
+  const saved = {};
+  const root = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [{ id: 354, nameZh: "当前学期", startDate: "2026-09-07" }],
+    document: renderedDocument({ cardsByDay: { 6: ["周六课程\n体育场 (2周) 6 (5节)"] } }),
+    fetch: async (url) => url.includes("get-data")
+      ? jsonResponse({ lessonIds: [], timeTableLayoutId: null, weekIndices: [1, 2] })
+      : jsonResponse({}),
+  }, saved);
+
+  const result = await adapter.runImportFlow(root);
+  assert.equal(result.success, true);
+  assert.equal(result.fallbackUsed, true);
+  assert.equal(saved.courses[0].day, 6);
+  assert.deepEqual(saved.courses[0].weeks, [2]);
+});
+
+test("never reuses the current page DOM when a different selected semester fails", async () => {
+  const saved = {};
+  const root = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [
+      { id: 354, nameZh: "当前学期", startDate: "2026-09-07" },
+      { id: 334, nameZh: "历史学期", startDate: "2026-03-02" },
+    ],
+    document: renderedDocument({ cardsByDay: { 7: ["当前课程\n教室 (1周) 7 (1节)"] } }),
+    fetch: async () => jsonResponse("登录页", { rawText: "<html>login</html>" }),
+  }, saved, { selectedIndex: 1 });
+
+  const result = await adapter.runImportFlow(root);
+  assert.equal(result.success, false);
+  assert.match(result.error, /非 JSON/);
+  assert.equal(saved.courses, undefined);
+  assert.equal(saved.completed, undefined);
+});
+
+test("uses rendered units when the optional layout endpoint fails", async () => {
+  const saved = {};
+  const root = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [{ id: 354, nameZh: "当前学期", startDate: "2026-09-07" }],
+    document: renderedDocument(),
+    fetch: async (url) => {
+      if (url.includes("get-data")) {
+        return jsonResponse({ lessonIds: [1], timeTableLayoutId: 9, lessonId2Flag: { 1: "publish" }, weekIndices: [1] });
+      }
+      if (url.includes("/datum")) {
+        return jsonResponse({
+          result: {
+            lessonList: [{ id: 1, courseName: "接口课程" }],
+            scheduleList: [{ lessonId: 1, weekday: 1, weekIndex: 1, startTime: 800, endTime: 940 }],
+          },
+        });
+      }
+      return jsonResponse({}, { ok: false, status: 503 });
+    },
+  }, saved);
+
+  const result = await adapter.runImportFlow(root);
+  assert.equal(result.success, true);
+  assert.equal(result.fallbackUsed, false);
+  assert.equal(saved.courses[0].startSection, 1);
+  assert.equal(saved.courses[0].endSection, 2);
+  assert.equal(saved.timeSlots.length, 12);
+  assert.match(saved.alert.content, /教务作息接口不可用/);
+});
+
+test("treats time-slot and course-config save failures as non-fatal warnings", async () => {
+  const saved = {};
+  const root = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [{ id: 354, nameZh: "当前学期", startDate: "2026-09-07" }],
+    document: renderedDocument(),
+    fetch: async (url) => {
+      if (url.includes("get-data")) return jsonResponse({ lessonIds: [1], timeTableLayoutId: 9, weekIndices: [1] });
+      if (url.includes("/datum")) {
+        return jsonResponse({ result: {
+          lessonList: [{ id: 1, courseName: "课程" }],
+          scheduleList: [{ lessonId: 1, weekday: 1, weekIndex: 1, startTime: 800, endTime: 845 }],
+        } });
+      }
+      return jsonResponse({ result: { courseUnitList: COURSE_UNITS } });
+    },
+  }, saved, {
+    promiseBridge: {
+      savePresetTimeSlots: async () => { throw new Error("slot failure"); },
+      saveCourseConfig: async () => { throw new Error("config failure"); },
+    },
+  });
+
+  const result = await adapter.runImportFlow(root);
+  assert.equal(result.success, true);
+  assert.deepEqual(result.warnings, ["作息时间保存失败", "学期配置保存失败"]);
+  assert.match(saved.alert.content, /作息时间保存失败；学期配置保存失败/);
+  assert.equal(saved.completed, true);
+});
+
+test("handles selection cancellation, missing bridges and genuinely empty semesters", async () => {
+  let fetchCalled = false;
+  const cancelledRoot = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [{ id: 354, nameZh: "当前学期" }],
+    document: renderedDocument(),
+    fetch: async () => { fetchCalled = true; return jsonResponse({}); },
+  }, {}, { selectedIndex: -1 });
+  assert.deepEqual(await adapter.runImportFlow(cancelledRoot), { cancelled: true });
+  assert.equal(fetchCalled, false);
+
+  const missingBridge = await adapter.runImportFlow({});
+  assert.equal(missingBridge.success, false);
+  assert.match(missingBridge.error, /Bridge/);
+
+  const dismissedError = await adapter.runImportFlow(addBridges({
+    location: { pathname: "/dashboard" },
+    semesters: [],
+    document: { querySelector: () => null },
+  }, {}, {
+    promiseBridge: { showAlert: async () => { throw new Error("dismissed"); } },
+  }));
+  assert.equal(dismissedError.success, false);
+  assert.match(dismissedError.error, /个人课表/);
+
+  const saved = {};
+  const emptyRoot = addBridges({
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [{ id: 354, nameZh: "当前学期" }],
+    document: renderedDocument({ courseUnits: [] }),
+    fetch: async () => jsonResponse({ lessonIds: [], timeTableLayoutId: null }),
+  }, saved);
+  const emptyResult = await adapter.runImportFlow(emptyRoot);
+  assert.equal(emptyResult.success, false);
+  assert.match(emptyResult.error, /没有可导入/);
+});
+
 test("derives an inclusive semester length when week indices are unavailable", () => {
   const config = adapter.buildCourseConfig(
     { startDate: "2026-09-07", endDate: "2027-01-17", weekStartOnSunday: false },
@@ -195,4 +746,35 @@ test("derives an inclusive semester length when week indices are unavailable", (
     adapter.normalizeCourseUnits(COURSE_UNITS)
   );
   assert.equal(config.semesterTotalWeeks, 19);
+});
+
+test("prefers observed weeks and handles Sunday-based or invalid semester dates safely", () => {
+  const observed = adapter.buildCourseConfig(
+    { startDate: "2026-09-06", endDate: "2026-09-12", weekStartOnSunday: true },
+    { weekIndices: ["1", "18", "invalid"] },
+    [{ weeks: [20] }],
+    adapter.normalizeCourseUnits(COURSE_UNITS)
+  );
+  assert.equal(observed.semesterTotalWeeks, 20);
+  assert.equal(observed.firstDayOfWeek, 7);
+  assert.equal(observed.defaultClassDuration, 45);
+  assert.equal(observed.defaultBreakDuration, 10);
+
+  const reversed = adapter.buildCourseConfig(
+    { startDate: "2026-09-07", endDate: "2026-09-01", weekStartOnSunday: false },
+    { weekIndices: [] },
+    [],
+    []
+  );
+  assert.equal(reversed.semesterTotalWeeks, 20);
+  assert.equal(reversed.semesterStartDate, "2026-09-07");
+
+  const invalid = adapter.buildCourseConfig(
+    { startDate: "2026-02-31", endDate: "2026-06-30", weekStartOnSunday: false },
+    { weekIndices: [] },
+    [],
+    []
+  );
+  assert.equal(invalid.semesterStartDate, null);
+  assert.equal(invalid.semesterTotalWeeks, 20);
 });

--- a/tests/hfut_eams5.test.js
+++ b/tests/hfut_eams5.test.js
@@ -1,0 +1,198 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const adapter = require("../resources/HFUT/hfut_eams5.js");
+
+const COURSE_UNITS = [
+  [800, 845],
+  [855, 940],
+  [1000, 1045],
+  [1055, 1140],
+  [1400, 1445],
+  [1455, 1540],
+  [1550, 1635],
+  [1645, 1730],
+  [1740, 1825],
+  [1920, 2005],
+  [2015, 2100],
+  [2110, 2155],
+].map(([startTime, endTime]) => ({ startTime, endTime }));
+
+test("normalizes the twelve EAMS5 course units from the saved HFUT page format", () => {
+  const units = adapter.normalizeCourseUnits(COURSE_UNITS);
+  assert.equal(units.length, 12);
+  assert.deepEqual(units[0], {
+    number: 1,
+    startMinutes: 480,
+    endMinutes: 525,
+    startTime: "08:00",
+    endTime: "08:45",
+  });
+  assert.equal(units[11].startTime, "21:10");
+  assert.equal(units[11].endTime, "21:55");
+});
+
+test("converts per-week records and keeps Saturday, Sunday, room changes and custom times", () => {
+  const lessonList = [
+    { id: 1, courseName: "编译原理", teacherAssignmentList: [{ name: "张老师" }] },
+    { id: 2, courseName: "周末实践", teacherAssignmentList: [{ name: "李老师" }] },
+    { id: 3, courseName: "晚间讲座", teacherAssignmentList: [{ name: "王老师" }] },
+    { id: 4, courseName: "未发布课程" },
+  ];
+  const scheduleList = [
+    { lessonId: 1, scheduleGroupId: 10, weekday: 1, weekIndex: 1, startTime: 800, endTime: 940, periods: 2, personName: "张老师", room: { nameZh: "翠八教101" } },
+    { lessonId: 1, scheduleGroupId: 10, weekday: 1, weekIndex: 2, startTime: 800, endTime: 940, periods: 2, personName: "张老师", room: { nameZh: "翠八教101" } },
+    { lessonId: 2, scheduleGroupId: 20, weekday: 6, weekIndex: 3, startTime: 1000, endTime: 1140, personName: "李老师", room: { nameZh: "工程训练中心" } },
+    { lessonId: 2, scheduleGroupId: 20, weekday: 7, weekIndex: 4, startTime: 1000, endTime: 1140, personName: "李老师", room: { nameZh: "工程训练中心" } },
+    { lessonId: 2, scheduleGroupId: 21, weekday: 7, weekIndex: 5, startTime: 1400, endTime: 1540, personName: "李老师", room: { nameZh: "A101" } },
+    { lessonId: 2, scheduleGroupId: 21, weekday: 7, weekIndex: 6, startTime: 1400, endTime: 1540, personName: "李老师", room: { nameZh: "B202" } },
+    { lessonId: 3, scheduleGroupId: 30, weekday: 7, weekIndex: 8, startTime: 1830, endTime: 1915, customPlace: "线上" },
+    { lessonId: 4, scheduleGroupId: 40, weekday: 7, weekIndex: 1, startTime: 800, endTime: 845 },
+  ];
+
+  const courses = adapter.convertScheduleData({
+    lessonList,
+    scheduleList,
+    courseUnits: COURSE_UNITS,
+    publishedFlags: { 1: "publish", 2: "publish", 3: "publish", 4: "draft" },
+    semesterStartDate: "2026-09-07",
+  });
+
+  assert.deepEqual(courses.find((course) => course.name === "编译原理").weeks, [1, 2]);
+  assert.ok(courses.some((course) => course.day === 6));
+  assert.equal(courses.filter((course) => course.day === 7).length, 4);
+  assert.deepEqual(
+    courses.filter((course) => course.name === "周末实践" && course.day === 7).map((course) => [course.position, course.weeks]),
+    [["工程训练中心", [4]], ["A101", [5]], ["B202", [6]]]
+  );
+  assert.deepEqual(courses.find((course) => course.name === "晚间讲座"), {
+    name: "晚间讲座",
+    teacher: "王老师",
+    position: "线上",
+    day: 7,
+    weeks: [8],
+    isCustomTime: true,
+    customStartTime: "18:30",
+    customEndTime: "19:15",
+  });
+  assert.ok(!courses.some((course) => course.name === "未发布课程"));
+});
+
+test("parses rendered EAMS5 card text without assuming weekdays only", () => {
+  assert.deepEqual(
+    adapter.parseRenderedCardText("数据结构\n翠八教负09* (1~8周) 7 (3,4)", 7),
+    {
+      name: "数据结构",
+      teacher: "",
+      position: "翠八教负09*",
+      day: 7,
+      startSection: 3,
+      endSection: 4,
+      weeks: [1, 2, 3, 4, 5, 6, 7, 8],
+    }
+  );
+  assert.deepEqual(adapter.parseWeekText("1~15单周,2~16双周"), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+});
+
+test("the rendered-page fallback scans all seven weekday columns", () => {
+  const fakeCard = (text) => ({
+    classList: { contains: (name) => name === "card-view" },
+    querySelector: () => ({ innerText: text }),
+  });
+  const columns = Array.from({ length: 7 }, (_, index) => ({
+    children: index === 5
+      ? [fakeCard("周六课程\n翡翠湖校区 (2~4周) 6 (1,2)")]
+      : index === 6
+        ? [fakeCard("周日课程\n屯溪路校区 (1,3,5周) 7 (11,12)")]
+        : [],
+  }));
+  const documentObject = {
+    querySelectorAll: (selector) => selector.includes("columns.weekday") ? columns : [],
+  };
+
+  const courses = adapter.parseRenderedSchedule(documentObject);
+  assert.deepEqual(courses.map((course) => course.day), [6, 7]);
+  assert.deepEqual(courses[1].weeks, [1, 3, 5]);
+  assert.equal(courses[1].endSection, 12);
+});
+
+test("runs the complete bridge flow against mocked EAMS5 endpoints", async () => {
+  const saved = {};
+  const requests = [];
+  const responses = {
+    "get-data": {
+      timeTableLayoutId: 99,
+      lessonIds: [7],
+      lessons: [{ id: 7, courseName: "周日实验", teacherAssignmentList: [{ name: "陈老师" }] }],
+      lessonId2Flag: { 7: "publish" },
+      weekIndices: Array.from({ length: 20 }, (_, index) => index + 1),
+    },
+    datum: {
+      result: {
+        lessonList: [{ id: 7, courseName: "周日实验", teacherAssignmentList: [{ name: "陈老师" }] }],
+        scheduleList: [
+          { lessonId: 7, scheduleGroupId: 1, weekday: 7, weekIndex: 2, startTime: 800, endTime: 940, room: { nameZh: "实验楼201" } },
+        ],
+      },
+    },
+    layout: { result: { courseUnitList: COURSE_UNITS } },
+  };
+  const root = {
+    CONTEXT_PATH: "/eams5-student",
+    studentId: 12345,
+    location: { pathname: "/eams5-student/for-std/course-table/info/12345" },
+    currentSemester: { id: 354 },
+    semesters: [
+      { id: 354, nameZh: "2026-2027学年第一学期", startDate: "2026-09-07", endDate: "2027-01-17", weekStartOnSunday: false },
+    ],
+    document: { querySelector: () => null },
+    fetch: async (url, init) => {
+      requests.push({ url, init });
+      const payload = url.includes("get-data") ? responses["get-data"] : url.includes("/datum") ? responses.datum : responses.layout;
+      return { ok: true, status: 200, text: async () => JSON.stringify(payload) };
+    },
+    shiguangBridgePromise: {
+      showSingleSelection: async () => 0,
+      saveImportedCourses: async (json) => { saved.courses = JSON.parse(json); },
+      savePresetTimeSlots: async (json) => { saved.timeSlots = JSON.parse(json); },
+      saveCourseConfig: async (json) => { saved.config = JSON.parse(json); },
+      showAlert: async () => true,
+    },
+    shiguangBridge: {
+      showToast: () => {},
+      notifyTaskCompletion: () => { saved.completed = true; },
+    },
+  };
+
+  const result = await adapter.runImportFlow(root);
+  assert.equal(result.success, true);
+  assert.equal(saved.courses[0].day, 7);
+  assert.deepEqual(saved.courses[0].weeks, [2]);
+  assert.equal(saved.timeSlots.length, 12);
+  assert.deepEqual(saved.config, {
+    semesterStartDate: "2026-09-07",
+    semesterTotalWeeks: 20,
+    defaultClassDuration: 45,
+    defaultBreakDuration: 10,
+    firstDayOfWeek: 1,
+  });
+  assert.equal(saved.completed, true);
+  assert.match(requests[0].url, /bizTypeId=2&semesterId=354&dataId=12345$/);
+  assert.deepEqual(JSON.parse(requests[1].init.body), {
+    lessonIds: [7],
+    studentId: 12345,
+    weekIndex: "",
+  });
+  assert.deepEqual(JSON.parse(requests[2].init.body), { timeTableLayoutId: 99 });
+});
+
+test("derives an inclusive semester length when week indices are unavailable", () => {
+  const config = adapter.buildCourseConfig(
+    { startDate: "2026-09-07", endDate: "2027-01-17", weekStartOnSunday: false },
+    { weekIndices: [] },
+    [],
+    adapter.normalizeCourseUnits(COURSE_UNITS)
+  );
+  assert.equal(config.semesterTotalWeeks, 19);
+});


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

- [x] 文件已经上传到对应的学校资源目录
- [x] 确认目标分支是 pending

## PR 描述 (Description)

新增合肥工业大学（HFUT）翱翔门户 Supwisdom EAMS5 本科/专科课表导入适配器。

### 实现内容

- 在根索引中登记 HFUT，并新增 HFUT_01 适配器配置。
- 复用个人课表页面的 get-data、datum 与 timetable-layout 接口，动态获取学期、逐周排课与作息时间。
- 支持星期一至星期日、单双周、教师或教室按周变化、多人或多地点，以及非标准上课时间。
- 当接口不可用，或当前学期接口返回空排课时，使用当前页面七列课表降级解析；不会把当前页面数据用于其他学期。
- 作息接口单独失败时仍会保留课程数据，并使用页面作息或课程实际时间导入。

### 兼容性与数据处理

- 兼容 Selectize 折叠原生学期选项的页面结构。
- 兼容单节、节次范围，以及“从第 N 节开始，连 M 节”的页面文本。
- 按 EAMS5 发布状态过滤课程。
- 标准节次与自定义时间统一按实际开始时间排序。
- 不包含用户示例课表或任何个人数据。

### 轻量测试

- JavaScript 语法检查通过。
- Node 测试 28/28 通过；行覆盖率 99.41%，分支覆盖率 90.24%，函数覆盖率 98.68%。
- YAML 与 JSON Schema 校验通过，适配器资源引用有效。
- 本地保存的 HFUT 页面共 24 个课程卡片，降级解析器识别 24/24。
- git diff --check 通过。

按项目约束仅执行轻量测试，未运行 Gradle、全仓构建或 Android 模拟器。