### PR TITLE
fix(YANGTZEU): 保留同一课程的全部节次分配

### DIFF
--- a/resources/YANGTZEU/yu.js
+++ b/resources/YANGTZEU/yu.js
@@ -158,7 +158,29 @@
         return args;
     }
 
-    // 从脚本文本中的 TaskActivity 还原课程
+    // 读取构造参数，避免教师表达式或课程名中的括号提前结束匹配。
+    function readTaskActivityArgs(text, start) {
+        let depth = 1;
+        let quote = "";
+        let escaped = false;
+        for (let i = start; i < text.length; i++) {
+            const ch = text[i];
+            if (quote) {
+                if (escaped) escaped = false;
+                else if (ch === "\\") escaped = true;
+                else if (ch === quote) quote = "";
+                continue;
+            }
+            if (ch === "\"" || ch === "'") quote = ch;
+            else if (ch === "(") depth++;
+            else if (ch === ")" && --depth === 0) {
+                return { argsText: text.slice(start, i), end: i + 1 };
+            }
+        }
+        return null;
+    }
+
+    // 每个 TaskActivity 可以分配到多个节次，先划分课程声明，再读取其全部 index。
     function parseCoursesFromTaskActivityScript(htmlText) {
         const text = String(htmlText || "");
         if (!text) return [];
@@ -166,30 +188,23 @@
         const unitCount = unitCountMatch ? parseInt(unitCountMatch[1], 10) : 0;
         if (!Number.isInteger(unitCount) || unitCount <= 0) return [];
         const courses = [];
-        const blockRe = /activity\s*=\s*new\s+TaskActivity\(([^]*?)\)\s*;\s*index\s*=\s*(?:(\d+)\s*\*\s*unitCount\s*\+\s*(\d+)|(\d+))\s*;\s*table\d+\.activities\[index\]/g;
+        const activities = [];
+        const activityRe = /\bactivity\s*=\s*new\s+TaskActivity\s*\(/g;
         let match;
-        while ((match = blockRe.exec(text)) !== null) {
-            const argsText = match[1] || "";
-            const args = splitJsArgs(argsText);
+        while ((match = activityRe.exec(text)) !== null) {
+            const call = readTaskActivityArgs(text, activityRe.lastIndex);
+            if (!call) break;
+            activities.push({ ...call, start: match.index });
+            activityRe.lastIndex = call.end;
+        }
+        for (let i = 0; i < activities.length; i++) {
+            const activity = activities[i];
+            const args = splitJsArgs(activity.argsText);
             if (args.length < 7) continue;
-            const dayPart = match[2];
-            const sectionPart = match[3];
-            const directIndexPart = match[4];
-            let indexValue = -1;
-            if (dayPart != null && sectionPart != null) {
-                indexValue = parseInt(dayPart, 10) * unitCount + parseInt(sectionPart, 10);
-            } else if (directIndexPart != null) {
-                indexValue = parseInt(directIndexPart, 10);
-            }
-            if (!Number.isInteger(indexValue) || indexValue < 0) continue;
-            const day = Math.floor(indexValue / unitCount) + 1;
-            let section = (indexValue % unitCount) + 1;
-            section = mapSectionToTimeSlotNumber(section);
-            if (day < 1 || day > 7 || section < 1 || section > 16) continue;
             let teacher = unquoteJsLiteral(args[1]);
             // 教师值为 JS 表达式时，尝试解析或置空以触发兜底
             if (teacher && /\.join\s*\(/.test(teacher)) {
-                const resolved = resolveTeachersForTaskActivityBlock(text, match.index, teacher);
+                const resolved = resolveTeachersForTaskActivityBlock(text, activity.start, teacher);
                 teacher = resolved || "";
             }
             const name = cleanCourseName(unquoteJsLiteral(args[3]));
@@ -197,15 +212,28 @@
             const weekBitmap = unquoteJsLiteral(args[6]);
             const weeks = normalizeWeeks(parseValidWeeksBitmap(weekBitmap));
             if (!name) continue;
-            courses.push({
-                name,
-                teacher,
-                position,
-                day,
-                startSection: section,
-                endSection: section,
-                weeks
-            });
+            const end = i + 1 < activities.length ? activities[i + 1].start : text.length;
+            const assignments = text.slice(activity.end, end);
+            const indexRe = /\bindex\s*=\s*(?:(\d+)\s*\*\s*unitCount\s*\+\s*(\d+)|(\d+))\s*;\s*table\d+\.activities\[index\]/g;
+            let indexMatch;
+            while ((indexMatch = indexRe.exec(assignments)) !== null) {
+                const indexValue = indexMatch[3] != null
+                    ? parseInt(indexMatch[3], 10)
+                    : parseInt(indexMatch[1], 10) * unitCount + parseInt(indexMatch[2], 10);
+                if (!Number.isInteger(indexValue) || indexValue < 0) continue;
+                const day = Math.floor(indexValue / unitCount) + 1;
+                const section = mapSectionToTimeSlotNumber((indexValue % unitCount) + 1);
+                if (day < 1 || day > 7 || section < 1 || section > 16) continue;
+                courses.push({
+                    name,
+                    teacher,
+                    position,
+                    day,
+                    startSection: section,
+                    endSection: section,
+                    weeks
+                });
+            }
         }
         return mergeContiguousSections(courses);
     }

--- a/tests/yangtzeu.test.cjs
+++ b/tests/yangtzeu.test.cjs
@@ -1,0 +1,139 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+
+const adapter = fs.readFileSync(path.join(__dirname, '../resources/YANGTZEU/yu.js'), 'utf8');
+
+// Synthetic EAMS data; the repeated index assignments follow the observed page format.
+// No student identifiers, real teachers, or personal timetable data are used here.
+function activity({ name = '测试实验', teacher = '测试教师', weeks = '011010', indices = ['6*unitCount+0'], expression = false } = {}) {
+    const teacherExpression = expression ? "actTeacherName.join(',')" : JSON.stringify(teacher);
+    return `
+        var actTeachers = [{id: 1, name: ${JSON.stringify(teacher)}, lab: false}];
+        var actTeacherName = [];
+        for (var i = 0; i < actTeachers.length; i++) {
+            actTeacherName.push(actTeachers[i].name);
+        }
+        activity = new TaskActivity('', ${teacherExpression}, 'course-id', ${JSON.stringify(name + '(123.1)')}, 'room-id', '测试教室', '${weeks}', null, null, '', '', '');
+        ${indices.map(index => `index = ${index}; table0.activities[index][table0.activities[index].length] = activity;`).join('\n')}
+    `;
+}
+
+async function runAdapter(courseScript, { selection = 0, entry = true } = {}) {
+    const result = { courses: [], slots: [], requests: [], alerts: [], toasts: [], writes: 0, completed: false };
+    let finish;
+    const finished = new Promise(resolve => { finish = resolve; });
+    const context = {
+        console: { error() {}, log() {} },
+        fetch: async (url, options) => {
+            result.requests.push({ url, options });
+            let text;
+            if (url.includes('courseTableForStd!courseTable.action')) {
+                text = `<script>var unitCount = 8; var activity = null; ${courseScript}</script>`;
+            } else if (url.includes('dataQuery.action')) {
+                text = `({semesters: {'2026': [{id: '1', schoolYear: '2026-2027', name: '1'}]}})`;
+            } else {
+                text = entry ? '<input id="semesterBar123Semester"><script>bg.form.addInput(form,"ids","1001");</script>' : '<form>请先登录</form>';
+            }
+            return { ok: true, text: async () => text };
+        },
+        window: {
+            shiguangBridgePromise: {
+                showAlert: async (...args) => { result.alerts.push(args); finish(); return true; },
+                showSingleSelection: async () => selection,
+                saveImportedCourses: async data => { result.courses = JSON.parse(data); result.writes++; },
+                savePresetTimeSlots: async data => { result.slots = JSON.parse(data); result.writes++; }
+            },
+            shiguangBridge: {
+                showToast(message) {
+                    result.toasts.push(message);
+                    if (/已取消|导入失败/.test(message)) finish();
+                },
+                notifyTaskCompletion() { result.completed = true; finish(); }
+            }
+        }
+    };
+    vm.runInNewContext(adapter, context, { timeout: 1000 });
+    let timer;
+    try {
+        await Promise.race([
+            finished,
+            new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('Adapter did not finish')), 2000); })
+        ]);
+    } finally {
+        clearTimeout(timer);
+    }
+    return result;
+}
+
+test('preserves both consecutive slots of one activity and the resulting end time', async () => {
+    const result = await runAdapter(activity({ indices: ['6*unitCount+0', '6*unitCount+1'], expression: true }));
+    assert.equal(result.completed, true);
+    assert.equal(result.courses.length, 1);
+    assert.deepEqual(result.courses[0], {
+        name: '测试实验', teacher: '测试教师', position: '测试教室', day: 7,
+        startSection: 1, endSection: 2, weeks: [1, 2, 4]
+    });
+    assert.equal(result.slots.find(slot => slot.number === result.courses[0].endSection).endTime, '11:40');
+    assert.equal(result.requests.length, 3);
+});
+
+test('keeps noncontiguous periods separate after the school-specific slot mapping', async () => {
+    const result = await runAdapter(activity({ indices: ['0*unitCount+0', '0*unitCount+2'] }));
+    assert.deepEqual(result.courses.map(course => [course.startSection, course.endSection]), [[1, 1], [4, 4]]);
+});
+
+test('keeps assignments on different days', async () => {
+    const result = await runAdapter(activity({ indices: ['0*unitCount+0', '2*unitCount+0'] }));
+    assert.deepEqual(result.courses.map(course => course.day), [1, 3]);
+});
+
+test('supports repeated direct numeric indices', async () => {
+    const result = await runAdapter(activity({ indices: ['48', '49'] }));
+    assert.deepEqual(result.courses.map(course => [course.day, course.startSection, course.endSection]), [[7, 1, 2]]);
+});
+
+test('does not assign the next activity to the previous course', async () => {
+    const result = await runAdapter(
+        activity({ name: '课程A', teacher: '教师A', indices: ['0*unitCount+0', '0*unitCount+1'], expression: true }) +
+        activity({ name: '课程B', teacher: '教师B', indices: ['2*unitCount+2'], expression: true })
+    );
+    assert.deepEqual(result.courses.map(({ name, teacher, day, startSection, endSection }) => ({ name, teacher, day, startSection, endSection })), [
+        { name: '课程A', teacher: '教师A', day: 1, startSection: 1, endSection: 2 },
+        { name: '课程B', teacher: '教师B', day: 3, startSection: 4, endSection: 4 }
+    ]);
+});
+
+test('does not interpret constructor-like punctuation inside quoted names', async () => {
+    const result = await runAdapter(activity({ name: '实验); 课程 "A"', expression: true }));
+    assert.equal(result.courses[0].name, '实验); 课程 "A"');
+    assert.equal(result.courses[0].teacher, '测试教师');
+});
+
+test('keeps empty scheduled teachers empty instead of borrowing the preceding teacher', async () => {
+    const result = await runAdapter(
+        activity({ name: '课程A', expression: true }) +
+        activity({ name: '课程B', teacher: '', indices: ['3*unitCount+3'], expression: true })
+    );
+    assert.equal(result.courses.find(course => course.name === '课程B').teacher, '');
+});
+
+test('cancelled semester selection writes no data', async () => {
+    const result = await runAdapter(activity(), { selection: null });
+    assert.equal(result.writes, 0);
+    assert.equal(result.completed, false);
+});
+
+test('missing login parameters writes no data', async () => {
+    const result = await runAdapter(activity(), { entry: false });
+    assert.equal(result.writes, 0);
+    assert.equal(result.alerts.length, 1);
+});
+
+test('empty timetable writes no data', async () => {
+    const result = await runAdapter('');
+    assert.equal(result.writes, 0);
+    assert.equal(result.completed, false);
+});


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

* [x] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)

## PR 描述 (Description)

修复长江大学课表中同一个 TaskActivity 分配到多个 index 时只导入第一段的问题。先划分课程构造声明，再解析每个声明范围内全部节次；连续时段沿用原有合并规则，不相邻时段和跨星期的安排分别保留。教师表达式解析和学校节次映射保持原有行为。

通过官方 Chrome 测试器在实际本科教务页面执行后，导出的 15 条排课记录和 8 个时间段与预期一致。相比旧脚本，仅一条连续两时段实验课由 `endSection: 1` 修正为 `endSection: 2`，其余记录及教师、地点、星期、周次保持一致。公开测试只使用虚构样本。

验证：

- `node --check resources/YANGTZEU/yu.js` 通过。
- `node --test tests/yangtzeu.test.cjs`：修复前 5 项失败，修复后 10 项全部通过。
- 官方 `shiguang_Tester` 的实际 `CourseTableExport.json` 导出已逐字段核对通过。
- 覆盖连续/非连续时段、跨星期分配、直接数字 index、课程边界、教师表达式、字符串括号/引号，以及取消/未登录/空课表不写入。
- `git diff --check` 通过。

Android 官方 v2.0.0 App 已复现旧脚本的 `1-1 节` 问题；修复脚本加载后，认证页的 HTTPS 证书错误阻塞了再次导入，因此未将 Android 端到端验收记为通过。真实个人课表未纳入补丁。
