### PR TITLE
fix: 重庆城市科技学院课表改 API 拉取，修复丢课与周次解析

### DIFF
--- a/resources/CQCST/cqcst_01.js
+++ b/resources/CQCST/cqcst_01.js
@@ -1,3 +1,4 @@
+
 async function runImportFlow() {
     // 兼容电脑端测试
     if (typeof window.shiguangBridgePromise === 'undefined') {


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `pending`。** (请勿直接合并到 `main` 或其他发布分支。)

## PR 描述 (Description)

修复重庆城市科技学院（CQCST）适配的多个问题：

- 课表数据改为直接请求强智 API（getKbcxList），不再依赖页面 DOM 解析，
  修复页面 innerText 解析丢失大量课程的问题；无需先打开课表页
- API 不可用时自动回退页面解析（保留旧版算法）
- 周次解析锚定 `[节]` 并剥离班级号，避免几乎全部课程被过滤
- 快捷导入默认当前学期，去掉多余的确认/成功 toast，避免与完成弹窗重复

修复系列由 **@Mutx163** 在轻屿仓库完成（原始提交为多个 fix，此处合并为一个提交），
桥接调用已适配 v2 接口。