### PR TITLE
fix：德州学院第5节为25分钟短节（11:50-12:15），修复时段重叠

### DIFF
--- a/resources/DZU/dzu_deep.js
+++ b/resources/DZU/dzu_deep.js
@@ -12,14 +12,14 @@ const WEEK_API_URL = "/jwglxt/kbcx/xskbcxZccx_cxZcByXnxq.html?gnmkdm=N2154";
 const INDEX_API_URL = "/jwglxt/kbcx/xskbcx_cxXskbcxIndex.html?gnmkdm=N2151";
 
 // 德州学院作息时间表（全年统一，不分夏季冬季）
-// 第 5 节仅出现在上午实验连排（第 3-5 节 10:00-12:15，三小节无课间连续），
-// 故取实验连排第三小节 11:30-12:15，使 3-5 节连排结束时间与作息表 12:15 精确对应。
+// 第 5 节为 25 分钟短节（11:50-12:15），上午（含实验连排）统一 12:15 结束：
+// 实验 3 小节（第 3-5 节）10:00-12:15 = 第3节45分 + 课间10 + 第4节45分 + 课间10 + 第5节25分。
 const TIME_SLOTS = [
     { number: 1, startTime: "08:00", endTime: "08:45" },
     { number: 2, startTime: "08:55", endTime: "09:40" },
     { number: 3, startTime: "10:00", endTime: "10:45" },
     { number: 4, startTime: "10:55", endTime: "11:40" },
-    { number: 5, startTime: "11:30", endTime: "12:15" },
+    { number: 5, startTime: "11:50", endTime: "12:15" },
     { number: 6, startTime: "14:00", endTime: "14:45" },
     { number: 7, startTime: "14:50", endTime: "15:35" },
     { number: 8, startTime: "15:55", endTime: "16:40" },


### PR DESCRIPTION
## 修正内容

#667 引入的第 5 节时间 `11:30-12:15` 与第 4 节 `10:55-11:40` **重叠 10 分钟**，App 写入作息时校验「时间段配置存在重叠」直接失败，导致德州学院导入报错。

经与德州学院学生确认，**第 5 节实际为 25 分钟短节 `11:50-12:15`**：

- 与第 4 节 11:40 下课间隔 10 分钟，无重叠 ✅
- 与作息表「实验3小节（第3-5节）10:00-12:15」精确自洽：
  第3节 45 分 + 课间 10 + 第4节 45 分 + 课间 10 + 第5节 25 分 = 135 分 = 10:00-12:15
  （上午理论/实验统一 12:15 结束）
- 已在 App 端实测通过（自定义仓库导入成功，无重叠报错，下午/晚上节次正确）

改动仅 `resources/DZU/dzu_deep.js` 第 5 节一行及注释，其余不变。

## 作息表来源

德院助手《德院校历|作息表》：https://www.yuque.com/deyuanzhushou/enoc41/pgw3sfnopsf6avpy

维护者 @yvmu